### PR TITLE
[CHG] Save as template

### DIFF
--- a/odoo_addons/mozaik_communication/tests/test_mass_function.py
+++ b/odoo_addons/mozaik_communication/tests/test_mass_function.py
@@ -36,3 +36,20 @@ class TestMassFunction(SharedSetupTransactionCase):
             cr, uid, [wiz_id], 'La guerre des étoiles', wiz.mass_mailing_name)
         self.assertFalse(values)
         return
+
+    def test_save_as_template(self):
+        mfct_obj = self.env['distribution.list.mass.function']
+        evr_lst_id = self.ref('%s.everybody_list' % self._module_ns)
+        vals = {
+            'trg_model': 'email.coordinate',
+            'e_mass_function': 'email_coordinate_id',
+            'distribution_list_id': evr_lst_id,
+            'subject': 'TEST1',
+            'body': '<p>hello</p>',
+        }
+        wizard = mfct_obj.with_context({'in_mozaik_user': True}).create(vals)
+        wizard.save_as_template()
+        self.assertTrue(bool(wizard.email_template_id))
+        self.assertEqual(wizard.email_template_id.subject, vals['subject'])
+        self.assertEqual(wizard.email_template_id.body_html, vals['body'])
+        self.assertEqual(wizard.email_template_id.model_id.model, 'email.coordinate')

--- a/odoo_addons/mozaik_communication/wizard/__init__.py
+++ b/odoo_addons/mozaik_communication/wizard/__init__.py
@@ -24,6 +24,7 @@
 ##############################################################################
 
 from . import distribution_list_mass_function
+from . import distribution_list_mass_function_v8
 from . import mail_compose_message
 from . import add_registration
 from . import export_csv_request

--- a/odoo_addons/mozaik_communication/wizard/distribution_list_mass_function_v8.py
+++ b/odoo_addons/mozaik_communication/wizard/distribution_list_mass_function_v8.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# © 2018 ACSONE SA/NV <https://acsone.eu/>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import api, models
+
+
+class DistributionListMassFunction(models.TransientModel):
+    _inherit = 'distribution.list.mass.function'
+
+    @api.multi
+    def save_as_template(self):
+        template_name = u"Mass Function: {subject}"
+        model = self.env['ir.model'].search(
+            [('model', '=', 'email.coordinate')], limit=1)
+        for record in self:
+            values = {
+                'name': template_name.format(subject=record.subject),
+                'subject': record.subject or False,
+                'body_html': record.body or False,
+                'model_id': model.id,
+            }
+            template = self.env['email.template'].create(values)
+            new_values = record.onchange_template_id(template.id)['value']
+            new_values['email_template_id'] = template.id
+            record.write(new_values)
+
+        return {
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'view_type': 'form',
+            'res_id': record.id,
+            'res_model': 'email.coordinate',
+            'target': 'new',
+            'context': dict(self.env.context),
+        }

--- a/odoo_addons/mozaik_communication/wizard/distribution_list_mass_function_view.xml
+++ b/odoo_addons/mozaik_communication/wizard/distribution_list_mass_function_view.xml
@@ -97,6 +97,10 @@
                             or
                         </span>
                         <button string="Cancel" class="oe_link" special="cancel" />
+
+                        <button type="object" name="save_as_template" string="Save as new template" class="pull-right"
+                            attrs="{'invisible':['|',('trg_model','!=','email.coordinate'),
+                                                     ('e_mass_function','!=','email_coordinate_id')]}"/>
                     </footer>
 
                 </form>


### PR DESCRIPTION
Implements essentially the same feature as in Odoo's mail composer, by creating an email.template from the subject/body and then linking the current message to it. 

I've created a new file for adding the code using the new API. If I should port the original file instead, just let me know.

refs #28189