### PR TITLE
[CHG] Add booleans to identify donors and volunteers

### DIFF
--- a/odoo_addons/mozaik_communication/views/virtual_models_view.xml
+++ b/odoo_addons/mozaik_communication/views/virtual_models_view.xml
@@ -103,6 +103,12 @@
                     <filter string="German" name="german"
                         domain="[('tongue','=','g')]" />
                     <separator />
+                    <filter string="Donor" name="donor"
+                        domain="[('is_donor','=',True)]" />
+                    <separator />
+                    <filter string="Volunteer" name="volunteer"
+                        domain="[('is_volunteer','=',True)]" />
+                    <separator />
                     <filter string="Employee" name="employee"
                         domain="[('employee','!=',0)]" />
                     <filter string="Not Employee" name="not_employee"
@@ -184,6 +190,8 @@
                     <field name="birth_date" />
                     <field name="gender" />
                     <field name="tongue" />
+                    <field name="is_donor" />
+                    <field name="is_volunteer" />
                     <field name="postal_unauthorized" invisible="1" />
                     <field name="email_unauthorized" invisible="1" />
                 </tree>
@@ -397,6 +405,12 @@
                     <filter string="German" name="german"
                         domain="[('tongue','=','g')]" />
                     <separator />
+                    <filter string="Donor" name="donor"
+                        domain="[('is_donor','=',True)]" />
+                    <separator />
+                    <filter string="Volunteer" name="volunteer"
+                        domain="[('is_volunteer','=',True)]" />
+                    <separator />
                     <filter string="Employee" name="employee"
                         domain="[('employee','!=',0)]" />
                     <filter string="Not Employee" name="not_employee"
@@ -465,6 +479,8 @@
                     <field name="birth_date" />
                     <field name="gender" />
                     <field name="tongue" />
+                    <field name="is_donor" />
+                    <field name="is_volunteer" />
                     <field name="postal_unauthorized" invisible="1" />
                     <field name="email_unauthorized" invisible="1" />
                 </tree>
@@ -1073,6 +1089,12 @@
                     <filter string="German" name="german"
                         domain="[('tongue','=','g')]" />
                     <separator />
+                    <filter string="Donor" name="donor"
+                        domain="[('is_donor','=',True)]" />
+                    <separator />
+                    <filter string="Volunteer" name="volunteer"
+                        domain="[('is_volunteer','=',True)]" />
+                    <separator />
                     <filter string="Employee" name="employee"
                         domain="[('employee','!=',0)]" />
                     <filter string="Not Employee" name="not_employee"
@@ -1116,6 +1138,8 @@
                     <field name="birth_date" />
                     <field name="gender" />
                     <field name="tongue" />
+                    <field name="is_donor" />
+                    <field name="is_volunteer" />
                     <field name="postal_unauthorized" invisible="1" />
                     <field name="email_unauthorized" invisible="1" />
                 </tree>

--- a/odoo_addons/mozaik_communication/virtual_models.py
+++ b/odoo_addons/mozaik_communication/virtual_models.py
@@ -145,6 +145,8 @@ class virtual_partner_involvement(orm.Model):
             rel='res_partner_term_interests_rel',
             id1='partner_id', id2='thesaurus_term_id', string='Interests'),
         'active': fields.boolean("Active"),
+        'is_donor': fields.boolean("Is a donor"),
+        'is_volunteer': fields.boolean("Is a volunteer"),
     }
 
 # orm methods
@@ -183,7 +185,9 @@ class virtual_partner_involvement(orm.Model):
                 WHEN (e.id IS NOT NULL OR pc.id IS NOT NULL)
                 THEN True
                 ELSE False
-            END AS active
+            END AS active,
+            p.is_donor,
+            p.is_volunteer
         FROM partner_involvement AS pi
 
         JOIN res_partner AS p
@@ -399,6 +403,8 @@ class virtual_partner_instance(orm.Model):
             rel='res_partner_term_interests_rel',
             id1='partner_id', id2='thesaurus_term_id', string='Interests'),
         'active': fields.boolean("Active"),
+        'is_donor': fields.boolean("Is a donor"),
+        'is_volunteer': fields.boolean("Is a volunteer"),
     }
 
 # orm methods
@@ -441,8 +447,9 @@ class virtual_partner_instance(orm.Model):
                     WHEN (e.id IS NOT NULL OR pc.id IS NOT NULL)
                     THEN True
                     ELSE False
-                END AS active
-
+                END AS active,
+                p.is_donor,
+                p.is_volunteer
             FROM res_partner AS p
 
             LEFT OUTER JOIN membership_state AS ms
@@ -1231,6 +1238,8 @@ class virtual_partner_membership(orm.Model):
             rel='res_partner_term_interests_rel',
             id1='partner_id', id2='thesaurus_term_id', string='Interests'),
         'active': fields.boolean('Active'),
+        'is_donor': fields.boolean("Is a donor"),
+        'is_volunteer': fields.boolean("Is a volunteer"),
     }
 
 # orm methods
@@ -1263,7 +1272,9 @@ class virtual_partner_membership(orm.Model):
                 WHEN (e.id IS NOT NULL OR pc.id IS NOT NULL)
                 THEN True
                 ELSE False
-            END AS active
+            END AS active,
+            p.is_donor,
+            p.is_volunteer
         FROM res_partner AS p
         JOIN membership_line AS m
             ON (m.partner_id = p.id

--- a/odoo_addons/mozaik_person/models/res_partner.py
+++ b/odoo_addons/mozaik_person/models/res_partner.py
@@ -2,7 +2,7 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import fields, models
+from openerp import fields, models, api
 
 
 class ResPartner(models.Model):
@@ -10,3 +10,22 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     nationality_id = fields.Many2one(track_visibility='onchange')
+    is_donor = fields.Boolean(
+        string="Is a donor",
+        compute='_compute_involvement_bools', store=True)
+    is_volunteer = fields.Boolean(
+        string="Is a volunteer",
+        compute='_compute_involvement_bools', store=True)
+
+    @api.multi
+    @api.depends(
+        'partner_involvement_ids',
+        'partner_involvement_ids.active',
+        'partner_involvement_inactive_ids',
+        'partner_involvement_inactive_ids.active',
+    )
+    def _compute_involvement_bools(self):
+        for partner in self:
+            types = partner.partner_involvement_ids.mapped('involvement_type')
+            partner.is_donor = 'donation' in types
+            partner.is_volunteer = 'voluntary' in types

--- a/odoo_addons/mozaik_person/res_partner_view.xml
+++ b/odoo_addons/mozaik_person/res_partner_view.xml
@@ -32,6 +32,10 @@
                     <filter string="French" name="french" domain="[('tongue','=','f')]" invisible="'default_is_company' not in context or context.get('default_is_company')"/>
                     <filter string="German" name="german" domain="[('tongue','=','g')]" invisible="'default_is_company' not in context or context.get('default_is_company')"/>
                     <separator />
+                    <filter string="Donor" name="donor" domain="[('is_donor','=',True)]"/>
+                    <separator />
+                    <filter string="Volunteer" name="volunteer" domain="[('is_volunteer','=',True)]"/>
+                    <separator />
                     <filter string="Employee" name="employee" domain="[('employee','!=',0)]" invisible="context.get('default_is_company')"/>
                     <filter string="Not Employee" name="not_employee" domain="[('employee','=',0)]" invisible="context.get('default_is_company')"/>
                     <separator />
@@ -282,6 +286,10 @@
                                           'search_default_all': True}" />
                         <button class="oe_right" string="Donations" name="%(partner_involvement_donation_action)d"
                                 type="action" attrs="{'invisible': [('id','=',False)]}" />
+                        <group>
+                            <field name="is_donor" />
+                            <field name="is_volunteer" />
+                        </group>
                         <field name="partner_involvement_ids" context="{'default_partner_id': active_id}"
                                attrs="{'invisible': [('active','=',False)], 'readonly': [('id','=',False)]}">
                             <tree>


### PR DESCRIPTION
Adds two checkboxes in the partner form that identifies if they have involvements of category "donation" or "voluntary". The boxes are also added to the Search Models lists.

refs #28742