### PR TITLE
[IMP] Improve the error message

### DIFF
--- a/odoo/addons/mozaik_communication/tests/test_distribution_list.py
+++ b/odoo/addons/mozaik_communication/tests/test_distribution_list.py
@@ -3,8 +3,7 @@
 
 import logging
 from uuid import uuid4
-from psycopg2 import IntegrityError
-
+from odoo.exceptions import ValidationError
 from odoo.tests.common import SavepointCase
 from odoo.tools.misc import mute_logger
 
@@ -141,7 +140,7 @@ class TestDistributionList(SavepointCase):
             code=newsletter.code,
             newsletter=True,
         )
-        with self.assertRaises(IntegrityError), mute_logger('odoo.sql_db'):
+        with self.assertRaises(ValidationError), mute_logger('odoo.sql_db'):
             self.dl_obj.create(vals)
         return
 

--- a/odoo/addons/mozaik_coordinate/tests/common_abstract_coordinate.py
+++ b/odoo/addons/mozaik_coordinate/tests/common_abstract_coordinate.py
@@ -42,7 +42,7 @@ class CommonAbstractCoordinate(CommonCoordinate):
         })
         # Disable error into logs
         self.env.cr._default_log_exceptions = False
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValidationError):
             self.model_coordinate.create(values)
         self.env.cr._default_log_exceptions = True
         return

--- a/odoo/addons/mozaik_involvement/tests/test_partner_involvement.py
+++ b/odoo/addons/mozaik_involvement/tests/test_partner_involvement.py
@@ -2,7 +2,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import datetime, timedelta
-import psycopg2
 
 from odoo.tests.common import SavepointCase
 
@@ -75,7 +74,7 @@ class TestPartnerInvolvement(SavepointCase):
         # copy it: OK
         involvement.copy()
         # create an already existing involvement: NOK
-        with self.assertRaises(psycopg2.IntegrityError), \
+        with self.assertRaises(exceptions.ValidationError), \
                 mute_logger('odoo.sql_db'):
             self.env['partner.involvement'].create({
                 'partner_id': paul.id,

--- a/odoo/addons/mozaik_membership/models/membership_line.py
+++ b/odoo/addons/mozaik_membership/models/membership_line.py
@@ -1,7 +1,6 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-from odoo import api, models, fields
+from odoo import api, models, fields, _
 import odoo.addons.decimal_precision as dp
 
 
@@ -66,3 +65,19 @@ class MembershipLine(models.Model):
             vals['date_to'] = fields.date.today()
 
         return super().action_invalidate(vals=vals)
+
+    @api.model
+    def _get_exception_messages(self):
+        """
+        Build a dict where the key is the constraint name (index name) and the
+        value is the error message to raise (with a ValidationError).
+        :return: dict
+        """
+        result = super(MembershipLine, self)._get_exception_messages()
+        index_name = self._get_index_name()
+        message = _("The partner already have an active subscription "
+                    "to this instance")
+        result.update({
+            index_name: message,
+        })
+        return result

--- a/odoo/addons/mozaik_thesaurus/tests/test_thesaurus.py
+++ b/odoo/addons/mozaik_thesaurus/tests/test_thesaurus.py
@@ -1,8 +1,6 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-from psycopg2 import IntegrityError
-
+from odoo.exceptions import ValidationError
 from odoo.tests import SavepointCase
 from odoo.tools.misc import mute_logger
 
@@ -16,6 +14,6 @@ class TestThesaurus(SavepointCase):
 
     def test_thesaurus_unique_name(self):
         # already thesaurus see data
-        with self.assertRaises(IntegrityError), mute_logger('odoo.sql_db'):
+        with self.assertRaises(ValidationError), mute_logger('odoo.sql_db'):
             self.thesaurus_model.create(
                 {'name': 'Thesaurus'})


### PR DESCRIPTION
Improve error message during `create`/`write` of models who inherit `mozaik.abstract.model`
So, models have to overwrite the `_get_exception_messages()` function to specify a message for a specific SQL constraint name.
Also, add the function `_get_index_name()` to have the generated constraint name.