### PR TITLE
[CHG] remove bridge_field from distribution list and useless _get_computed_targets() method

### DIFF
--- a/odoo/addons/distribution_list/views/distribution_list.xml
+++ b/odoo/addons/distribution_list/views/distribution_list.xml
@@ -82,11 +82,6 @@
                                 </tree>
                             </field>
                         </page>
-                        <page name="technical" string="Technical">
-                            <group>
-                                <field name="bridge_field"/>
-                            </group>
-                        </page>
                     </notebook>
                 </sheet>
             </form>

--- a/odoo/addons/distribution_list/views/distribution_list_line.xml
+++ b/odoo/addons/distribution_list/views/distribution_list_line.xml
@@ -58,9 +58,9 @@
                     <group name="data">
                         <group name="info">
                             <field name="distribution_list_id" invisible="context.get('default_distribution_list_id')" attrs="{'readonly': [('id','!=',False)]}"/>
-                            <field name="src_model_id" widget="selection"/>
-                            <field name="src_model_model" invisible="1"/>
-                            <field name="bridge_field_id" options="{'no_create_edit': True}"/>
+                            <field name="src_model_id" widget="selection" attrs="{'readonly': [('id','!=',False)]}"/>
+                            <field name="trg_model" invisible="1"/>
+                            <field name="bridge_field_id" widget="selection" attrs="{'readonly': [('id','!=',False)]}"/>
                         </group>
                         <group name="company">
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create_edit': True}"/>
@@ -71,6 +71,7 @@
                             <group name="expr">
                                 <field name="exclude" invisible="'default_exclude' in context"/>
                                 <field name="domain" readonly="1"/>
+                                <field name="src_model_model" invisible="1"/>
                                 <button class="oe_read_only" name="action_redefine_domain" type="object" string="Define New Expression" groups="distribution_list.res_groups_distribution_list_user"/>
                             </group>
                         </page>

--- a/odoo/addons/distribution_list/wizards/distribution_list_add_filter.py
+++ b/odoo/addons/distribution_list/wizards/distribution_list_add_filter.py
@@ -11,8 +11,8 @@ class DistributionListAddFilter(models.TransientModel):
     _description = 'Add Filter Wizard'
 
     distribution_list_id = fields.Many2one(
-        "distribution.list",
-        "Distribution list",
+        comodel_name="distribution.list",
+        string="Distribution list",
         required=True,
         ondelete="cascade",
     )
@@ -26,8 +26,8 @@ class DistributionListAddFilter(models.TransientModel):
         default=False,
     )
     bridge_field_id = fields.Many2one(
-        "ir.model.fields",
-        "Bridge field",
+        comodel_name="ir.model.fields",
+        string="Bridge field",
         required=True,
         ondelete="cascade",
     )

--- a/odoo/addons/distribution_list/wizards/distribution_list_add_filter.xml
+++ b/odoo/addons/distribution_list/wizards/distribution_list_add_filter.xml
@@ -9,7 +9,7 @@
         <field name="arch" type="xml">
             <form>
 
-                <div invisible="context.get('active_domain','x') == 'x'">
+                <div invisible="not context.get('active_domain')">
                     <div class="oe_title"  name="title">
                         <h1>
                             <field name="name" nolabel="1" placeholder="New Filter Name" />
@@ -17,20 +17,20 @@
                     </div>
                     <group>
                         <field name="distribution_list_id"/>
-                        <field name="bridge_field_id" options="{'no_create_edit': True}"/>
+                        <field name="bridge_field_id" widget="selection"/>
                         <field name="exclude"/>
                     </group>
                 </div>
-                <div invisible="not context.get('active_domain','x') == 'x'">
-                    Warning! You have to check the entire list to add the current filter
+                <div invisible="context.get('active_domain')">
+                    Warning! You have to define the filter before to add it into a distribution list
                 </div>
 
-                <footer invisible="context.get('active_domain','x') == 'x'">
+                <footer invisible="not context.get('active_domain')">
                     <button name="add_distribution_list_line" string="Add" type="object" class="btn-primary"/>
                     or
                     <button string="Cancel" class="btn-default" special="cancel" />
                 </footer>
-                <footer invisible="not context.get('active_domain','x') == 'x'">
+                <footer invisible="context.get('active_domain')">
                     <button string="Cancel" class="btn-default" special="cancel" />
                 </footer>
 

--- a/odoo/addons/mass_mailing_distribution_list/models/distribution_list.py
+++ b/odoo/addons/mass_mailing_distribution_list/models/distribution_list.py
@@ -234,18 +234,16 @@ class DistributionList(models.Model):
         return True
 
     @api.multi
-    def _get_target_from_distribution_list(self, safe_mode=True):
+    def _get_target_from_distribution_list(self):
         """
         manage opt in/out.
         If the distribution list is a newsletter and has a parther_path then:
         * remove all res_ids that contains a partner id into the opt_out_ids
         * add to res_ids all partner id into the opt_in_ids
-        :param safe_mode: bool
         :return: target recordset
         """
         self.ensure_one()
-        targets = super()._get_target_from_distribution_list(
-            safe_mode=safe_mode)
+        targets = super()._get_target_from_distribution_list()
         if self.newsletter and self.partner_path:
             partner_path = self.partner_path
             # opt in

--- a/odoo/addons/mass_mailing_distribution_list/views/distribution_list.xml
+++ b/odoo/addons/mass_mailing_distribution_list/views/distribution_list.xml
@@ -38,10 +38,6 @@
                 <field name="newsletter" />
             </xpath>
 
-            <xpath expr="//field[@name='bridge_field']" position="after">
-                <field name="partner_path" attrs="{'invisible': [('mail_forwarding', '=', 'False')], 'required':[('newsletter','=', True)]}" />
-            </xpath>
-
             <xpath expr="//group[@name='data']" position="inside">
                 <group>
                     <field name="mail_forwarding"/>
@@ -58,7 +54,7 @@
                 </group>
             </xpath>
 
-            <xpath expr="//page[@name='technical']" position="before">
+            <xpath expr="//notebook" position="inside">
                 <page name="optin" string="Opt-In" attrs="{'invisible': [('newsletter', '=', False)]}">
                     <field name="res_partner_opt_in_ids">
                         <tree>
@@ -74,6 +70,11 @@
                             <field name="email"/>
                         </tree>
                     </field>
+                </page>
+                <page name="technical" string="Technical">
+                    <group>
+                        <field name="partner_path" attrs="{'invisible': [('mail_forwarding', '=', 'False')], 'required':[('newsletter','=', True)]}" />
+                    </group>
                 </page>
             </xpath>
         </field>

--- a/odoo/addons/mozaik/__manifest__.py
+++ b/odoo/addons/mozaik/__manifest__.py
@@ -32,6 +32,11 @@
         'mozaik_structure',
         'mozaik_thesaurus',
         'mozaik_tools',
+        'mozaik_virtual_assembly_instance',
+        'mozaik_virtual_partner_instance',
+        'mozaik_virtual_partner_involvement',
+        'mozaik_virtual_partner_membership',
+        'mozaik_virtual_partner_relation',
         'partner_usual_firstname',
     ],
     'data': [

--- a/odoo/addons/mozaik_communication/models/abstract_virtual_model.py
+++ b/odoo/addons/mozaik_communication/models/abstract_virtual_model.py
@@ -90,7 +90,7 @@ class AbstractVirtualModel(models.AbstractModel):
             [('common_id', 'in', common_ids)])
         ids = {vt.common_id: vt.id for vt in vts}
         for record in self:
-            record.result_id = ids[record.common_id]
+            record.result_id = ids.get(record.common_id, False)
 
     @api.multi
     def see_partner_action(self):

--- a/odoo/addons/mozaik_communication/models/distribution_list_line.py
+++ b/odoo/addons/mozaik_communication/models/distribution_list_line.py
@@ -24,6 +24,25 @@ class DistributionListLine(models.Model):
     )
 
     @api.multi
+    def _get_target_recordset(self):
+        """
+        For excluding filters the result is transformed
+        to exclude all target records linked
+        to the concerned partners
+        :return: target recordset
+        """
+        results = super()._get_target_recordset()
+        partner_path = self.mapped('distribution_list_id').partner_path
+        if results and all(self.mapped('exclude')) and partner_path:
+            partners = results.mapped(partner_path)
+            if partners:
+                domain = [
+                    (partner_path, 'in', partners.ids),
+                ]
+                results = results.search(domain)
+        return results
+
+    @api.multi
     def action_show_filter_result_without_coordinate(self):
         """
         Show the result of the list without coordinate

--- a/odoo/addons/mozaik_communication/tests/__init__.py
+++ b/odoo/addons/mozaik_communication/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_distribution_list
 from . import test_mass_function
 from . import test_mail_template
 from . import test_email_template_placeholder
+from . import test_abstract_virtual_model

--- a/odoo/addons/mozaik_communication/tests/test_abstract_virtual_model.py
+++ b/odoo/addons/mozaik_communication/tests/test_abstract_virtual_model.py
@@ -1,0 +1,27 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestAbstractVirtualModel(TransactionCase):
+
+    def test_compute_result_id(self):
+        vt_model = self.env['virtual.target']
+        # get a partner with some coordinates
+        thierry_id = self.ref('mozaik_coordinate.res_partner_thierry')
+        vt = vt_model.search(
+            [('partner_id', '=', thierry_id)], limit=1)
+        # build a memory record with its common_id
+        vt_new = self.env['virtual.target'].new({
+            'common_id': vt.common_id,
+        })
+        vt_new._compute_result_id()
+        self.assertEqual(vt, vt_new.result_id)
+        # build a memory record with a non existing common_id
+        vt_new = self.env['virtual.target'].new({
+            'common_id': 'Les hommes savent pourquoi !',
+        })
+        vt_new._compute_result_id()
+        self.assertFalse(vt_new.result_id)
+        return

--- a/odoo/addons/mozaik_thesaurus/models/abstract_term_finder.py
+++ b/odoo/addons/mozaik_thesaurus/models/abstract_term_finder.py
@@ -31,5 +31,5 @@ class AbstractTermFinder(models.AbstractModel):
                     # default search domain
                     domain += [arg]
             args = domain
-        return super(AbstractTermFinder, self).search(
+        return super().search(
             args, offset=offset, limit=limit, order=order, count=count)

--- a/odoo/addons/mozaik_virtual_assembly_instance/__manifest__.py
+++ b/odoo/addons/mozaik_virtual_assembly_instance/__manifest__.py
@@ -19,6 +19,5 @@
         'views/virtual_assembly_instance.xml',
     ],
     'license': 'AGPL-3',
-    'auto_install': True,
     'installable': True,
 }

--- a/odoo/addons/mozaik_virtual_assembly_instance/models/__init__.py
+++ b/odoo/addons/mozaik_virtual_assembly_instance/models/__init__.py
@@ -1,3 +1,5 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import distribution_list_line
 from . import virtual_assembly_instance

--- a/odoo/addons/mozaik_virtual_assembly_instance/models/distribution_list_line.py
+++ b/odoo/addons/mozaik_virtual_assembly_instance/models/distribution_list_line.py
@@ -1,0 +1,18 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class DistributionListLine(models.Model):
+
+    _inherit = 'distribution.list.line'
+
+    @api.model
+    def _get_src_model_names(self):
+        """
+        Add a new virtual src model to list of valid models
+        :return: list of string
+        """
+        res = super()._get_src_model_names()
+        return res + ['virtual.assembly.instance']

--- a/odoo/addons/mozaik_virtual_partner_instance/__manifest__.py
+++ b/odoo/addons/mozaik_virtual_partner_instance/__manifest__.py
@@ -20,6 +20,5 @@
         'views/virtual_partner_instance.xml',
     ],
     'license': 'AGPL-3',
-    'auto_install': True,
     'installable': True,
 }

--- a/odoo/addons/mozaik_virtual_partner_instance/models/__init__.py
+++ b/odoo/addons/mozaik_virtual_partner_instance/models/__init__.py
@@ -1,3 +1,5 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import distribution_list_line
 from . import virtual_partner_instance

--- a/odoo/addons/mozaik_virtual_partner_instance/models/distribution_list_line.py
+++ b/odoo/addons/mozaik_virtual_partner_instance/models/distribution_list_line.py
@@ -1,0 +1,18 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class DistributionListLine(models.Model):
+
+    _inherit = 'distribution.list.line'
+
+    @api.model
+    def _get_src_model_names(self):
+        """
+        Add a new virtual src model to list of valid models
+        :return: list of string
+        """
+        res = super()._get_src_model_names()
+        return res + ['virtual.partner.instance']

--- a/odoo/addons/mozaik_virtual_partner_instance/models/virtual_partner_instance.py
+++ b/odoo/addons/mozaik_virtual_partner_instance/models/virtual_partner_instance.py
@@ -24,6 +24,10 @@ class VirtualPartnerInstance(models.Model):
         comodel_name='res.country',
         string='Nationality',
     )
+    membership_state_id = fields.Many2one(
+        comodel_name='membership.state',
+        string='State',
+    )
     postal_category_id = fields.Many2one(
         comodel_name='coordinate.category',
         string='Postal Coordinate Category',
@@ -36,10 +40,6 @@ class VirtualPartnerInstance(models.Model):
         string='Email Coordinate Category',
     )
     main_email = fields.Boolean(
-    )
-    membership_state_id = fields.Many2one(
-        comodel_name='membership.state',
-        string='State',
     )
 
     @api.model
@@ -56,11 +56,11 @@ class VirtualPartnerInstance(models.Model):
             p.is_donor,
             p.is_volunteer,
             p.nationality_id,
+            p.membership_state_id,
             pc.coordinate_category_id AS postal_category_id,
             pc.is_main AS main_postal,
             e.coordinate_category_id AS email_category_id,
-            e.is_main AS main_email,
-            ms.id AS membership_state_id"""
+            e.is_main AS main_email"""
         return select
 
     @api.model
@@ -70,8 +70,6 @@ class VirtualPartnerInstance(models.Model):
         :return: str
         """
         from_query = """FROM res_partner AS p
-            LEFT OUTER JOIN membership_state AS ms
-                ON (ms.id = p.membership_state_id)
             LEFT OUTER JOIN postal_coordinate AS pc
                 ON (pc.partner_id = p.id
                 AND pc.active = TRUE)

--- a/odoo/addons/mozaik_virtual_partner_involvement/__manifest__.py
+++ b/odoo/addons/mozaik_virtual_partner_involvement/__manifest__.py
@@ -21,6 +21,5 @@
         'views/virtual_partner_involvement.xml',
     ],
     'license': 'AGPL-3',
-    'auto_install': True,
     'installable': True,
 }

--- a/odoo/addons/mozaik_virtual_partner_involvement/models/__init__.py
+++ b/odoo/addons/mozaik_virtual_partner_involvement/models/__init__.py
@@ -1,3 +1,5 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import distribution_list_line
 from . import virtual_partner_involvement

--- a/odoo/addons/mozaik_virtual_partner_involvement/models/distribution_list_line.py
+++ b/odoo/addons/mozaik_virtual_partner_involvement/models/distribution_list_line.py
@@ -1,0 +1,18 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class DistributionListLine(models.Model):
+
+    _inherit = 'distribution.list.line'
+
+    @api.model
+    def _get_src_model_names(self):
+        """
+        Add a new virtual src model to list of valid models
+        :return: list of string
+        """
+        res = super()._get_src_model_names()
+        return res + ['virtual.partner.involvement']

--- a/odoo/addons/mozaik_virtual_partner_membership/__manifest__.py
+++ b/odoo/addons/mozaik_virtual_partner_membership/__manifest__.py
@@ -18,6 +18,5 @@
         'views/virtual_partner_membership.xml',
     ],
     'license': 'AGPL-3',
-    'auto_install': True,
     'installable': True,
 }

--- a/odoo/addons/mozaik_virtual_partner_membership/models/__init__.py
+++ b/odoo/addons/mozaik_virtual_partner_membership/models/__init__.py
@@ -1,3 +1,5 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import distribution_list_line
 from . import virtual_partner_membership

--- a/odoo/addons/mozaik_virtual_partner_membership/models/distribution_list_line.py
+++ b/odoo/addons/mozaik_virtual_partner_membership/models/distribution_list_line.py
@@ -1,0 +1,18 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class DistributionListLine(models.Model):
+
+    _inherit = 'distribution.list.line'
+
+    @api.model
+    def _get_src_model_names(self):
+        """
+        Add a new virtual src model to list of valid models
+        :return: list of string
+        """
+        res = super()._get_src_model_names()
+        return res + ['virtual.partner.membership']

--- a/odoo/addons/mozaik_virtual_partner_relation/__manifest__.py
+++ b/odoo/addons/mozaik_virtual_partner_relation/__manifest__.py
@@ -22,6 +22,5 @@
         'views/virtual_partner_relation.xml',
     ],
     'license': 'AGPL-3',
-    'auto_install': True,
     'installable': True,
 }

--- a/odoo/addons/mozaik_virtual_partner_relation/models/__init__.py
+++ b/odoo/addons/mozaik_virtual_partner_relation/models/__init__.py
@@ -1,3 +1,5 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import distribution_list_line
 from . import virtual_partner_relation

--- a/odoo/addons/mozaik_virtual_partner_relation/models/distribution_list_line.py
+++ b/odoo/addons/mozaik_virtual_partner_relation/models/distribution_list_line.py
@@ -1,0 +1,18 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class DistributionListLine(models.Model):
+
+    _inherit = 'distribution.list.line'
+
+    @api.model
+    def _get_src_model_names(self):
+        """
+        Add a new virtual src model to list of valid models
+        :return: list of string
+        """
+        res = super()._get_src_model_names()
+        return res + ['virtual.partner.relation']


### PR DESCRIPTION
In addition:
* virtual models are no longer auto_install
* complete list of valid models for each installed virtual model
* an order by into OVER() clause of virtual models are mandatory otherwise search() and read() results may be incompatible
* remove safe_mode parameter of _get_target_from_distribution_list()
* add a not store computed field result_id for each virtual model to translate common_id to a real id

