### PR TITLE
[FIX] mozaik_involvement_followup: next_category_ids shouldn't be computed if

### DIFF
--- a/mozaik_involvement_followup/wizards/partner_involvement_followup_wizard.py
+++ b/mozaik_involvement_followup/wizards/partner_involvement_followup_wizard.py
@@ -15,6 +15,9 @@ class PartnerInvolvementFollowupWizard(models.TransientModel):
         Compute domain for next_category_ids
         """
         domain = []
+        if self.env.context.get("active_model") == "res.partner":
+            # We shouldn't use active_id when active_model is res.partner
+            return []
         inv_ids = (
             self.env.context.get("active_ids")
             or [self.env.context.get("active_id")]


### PR DESCRIPTION
active_model is res.partner

refs #57895