### PR TITLE
[FIX] Address technical_name

### DIFF
--- a/mozaik_address/__manifest__.py
+++ b/mozaik_address/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "MOZAIK: Address",
     "summary": """
         Module for addresses, postal coordinates and co-residencies""",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV",
     "website": "https://github.com/OCA/mozaik",

--- a/mozaik_address/migrations/14.0.1.0.1/post-migrate.py
+++ b/mozaik_address/migrations/14.0.1.0.1/post-migrate.py
@@ -1,0 +1,14 @@
+# Copyright 2022 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Recompute address technical_name")
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env["address.address"].search([])._compute_integral_address()

--- a/mozaik_address/models/address_address.py
+++ b/mozaik_address/models/address_address.py
@@ -183,7 +183,7 @@ class AddressAddress(models.Model):
         return OrderedDict(
             [
                 ("country_id", "id"),
-                ("city_id", "zipcode"),
+                ("city_id", "id"),
                 ("zip_man", False),
                 ("city_man", False),
                 ("street_man", False),

--- a/mozaik_membership_request/models/membership_request.py
+++ b/mozaik_membership_request/models/membership_request.py
@@ -1046,16 +1046,12 @@ class MembershipRequest(models.Model):
     ):
         if not country_id:
             return EMPTY_ADDRESS
-        local_zip = False
         if city_id:
             zip_man, city_man = False, False
-            local_zip = self.env["res.city"].browse([city_id]).zipcode
-        if address_local_street_id:
-            street_man = False
         values = OrderedDict(
             [
                 ("country_id", country_id),
-                ("address_local_zip", local_zip),
+                ("city_id", city_id),
                 ("zip_man", zip_man),
                 ("city_man", city_man),
                 ("address_local_street_id", address_local_street_id),

--- a/mozaik_membership_request/tests/test_membership_request.py
+++ b/mozaik_membership_request/tests/test_membership_request.py
@@ -76,7 +76,7 @@ class TestMembership(TransactionCase):
             "mobile": "061411232",
         }
         all_values = {
-            "street": self.rec_address.address_local_street_id.local_street,
+            "street_man": self.rec_address.street_man,
             "zip_man": self.rec_address.city_id.zipcode,
             "address_local_street_id": self.rec_address.address_local_street_id.id,
             "box": self.rec_address.box,


### PR DESCRIPTION
@RobinetDenisAcsone 
Does this feels safe to you ?
We have got an issue because `technical_name` is in the `unicity_keys`.
To compute the `technical_name`, only the `zip` is taken from the `city_id`.
But really often the same address can be written with 2 different cities but the same zip.
For instance:
Grand Place 1, 4800 Ensival
Grand Place 1, 4800 Verviers