### PR TITLE
[FIX] mozaik_membership_request: interests were erased when pre_processing

### DIFF
--- a/mozaik_membership_request/models/membership_request.py
+++ b/mozaik_membership_request/models/membership_request.py
@@ -629,7 +629,10 @@ class MembershipRequest(models.Model):
         res = self._onchange_partner_id_vals(
             is_company, request_type, partner_id, technical_name
         )
+        old_interests = res.pop("interest_ids", [])
+        old_competencies = res.pop("competency_ids", [])
         vals.update(res)
+        self._merge_interests_competencies(vals, old_interests, old_competencies)
 
         vals.update(
             {
@@ -657,6 +660,29 @@ class MembershipRequest(models.Model):
         )
 
         return vals
+
+    def _merge_interests_competencies(self, vals, old_interests, old_competencies):
+        """
+        vals is a dict that may already contain a command for interest_ids or competency_ids.
+        We want to integrate to this command, the previous interests and competencies.
+
+        old_interests is either [] or [(6, False, [list_ids])]
+        old_competencies is either [] or [(6, False, [list_ids])]
+        """
+        new_interests = vals.pop("interest_ids", [])
+        new_competencies = vals.pop("competency_ids", [])
+        if old_interests:
+            old_interest_ids = old_interests[0][2]
+            new_interests += [(4, int_id) for int_id in old_interest_ids]
+        if old_competencies:
+            old_competency_ids = old_competencies[0][2]
+            new_competencies += [(4, comp_id) for comp_id in old_competency_ids]
+        vals.update(
+            {
+                "interest_ids": new_interests,
+                "competency_ids": new_competencies,
+            }
+        )
 
     @api.onchange("country_id")
     def onchange_country_id(self):

--- a/mozaik_membership_request/tests/test_membership_request.py
+++ b/mozaik_membership_request/tests/test_membership_request.py
@@ -43,6 +43,7 @@ class TestMembership(TransactionCase):
         self.mro = self.env["membership.request"]
         self.mrco = self.env["membership.request.change"]
         self.mrs = self.env["membership.state"]
+        self.tt = self.env["thesaurus.term"]
 
         self.rec_partner = self.browse_ref("mozaik_address.res_partner_thierry")
         self.rec_partner_pauline = self.browse_ref(
@@ -102,6 +103,56 @@ class TestMembership(TransactionCase):
             self.rec_partner.int_instance_ids.ids,
             "Instance should be the instance of the partner",
         )
+
+    def test_pre_process_interest_competencies(self):
+        """
+        Test that when pre-processing the data, old and new
+        interests / competencies are both kept.
+        """
+        interest_1 = self.tt.create({"name": "First interest"})
+        interest_2 = self.tt.create({"name": "Second interest"})
+        competency_1 = self.tt.create({"name": "First competency"})
+
+        # New partner, we add interests.
+
+        mr_values = {
+            "lastname": "Sy",
+            "firstname": "Omar",
+            "interest_ids": [(6, 0, [interest_1.id])],
+        }
+        mr = self.mro.with_context(mode="pre_process").create(mr_values)
+        self.assertEqual(mr.interest_ids.ids, [interest_1.id])
+
+        # Create a partner with some interests and competencies.
+
+        sy = self.env["res.partner"].create(
+            {
+                "lastname": "Sy",
+                "firstname": "Omar",
+                "interest_ids": [(4, interest_2.id)],
+            }
+        )
+
+        # Don't add any interest / competency, check that the existing
+        # ones are preserved on the membership request.
+        mr_values = {
+            "partner_id": sy.id,
+            "lastname": sy.lastname,
+        }
+        mr = self.mro.with_context(mode="pre_process").create(mr_values)
+        self.assertEqual(mr.interest_ids.ids, [interest_2.id])
+        self.assertEqual(mr.competency_ids.ids, [])
+
+        # Add more interest / competencies
+        mr_values = {
+            "partner_id": sy.id,
+            "lastname": sy.lastname,
+            "interest_ids": [(6, 0, [interest_1.id])],
+            "competency_ids": [(6, 0, [competency_1.id])],
+        }
+        mr = self.mro.with_context(mode="pre_process").create(mr_values)
+        self.assertEqual(set(mr.interest_ids.ids), {interest_1.id, interest_2.id})
+        self.assertEqual(mr.competency_ids.ids, [competency_1.id])
 
     def test_get_address_id(self):
         adrs = self.browse_ref("mozaik_address.address_3")


### PR DESCRIPTION
When creating a membership request and pre-processing the data, interest and competencies were not taken into account.