### PR TITLE
[UPD] mozaik_communication: rmv _get_target_recordset overwritting

### DIFF
--- a/distribution_list/models/distribution_list_line.py
+++ b/distribution_list/models/distribution_list_line.py
@@ -170,16 +170,24 @@ class DistributionListLine(models.Model):
             source_model = bridge_field.model_id.model
             field_name = bridge_field.name
             try:
-                results = self.env[source_model].search(big_domain)
-                if field_name == "id":
-                    targets |= results
-                else:
-                    # to speedup use read and not mapped
-                    ids = {
-                        r[field_name]
-                        for r in results.read([field_name], load="_classic_write")
-                    }
-                    targets |= self.env[target_model].browse(ids)
+                self.flush()
+                if field_name == "self":
+                    field_name = "id"
+                # not the best, but use directly the sql to improve perf
+                # without that, it will need 2 call, one search, one read
+                self.env[source_model].check_access_rights("read")
+                query = self.env[source_model]._where_calc(big_domain)
+                self.env[source_model]._apply_ir_rules(query, "read")
+                from_clause, where_clause, where_clause_params = query.get_sql()
+                query_str = 'SELECT "%s".%s FROM %s WHERE %s' % (
+                    self.env[source_model]._table,
+                    field_name,
+                    from_clause,
+                    where_clause,
+                )
+                self.env.cr.execute(query_str, where_clause_params)
+                ids = [r[0] for r in self.env.cr.fetchall()]
+                targets |= self.env[target_model].browse(ids)
             except Exception as e:
                 message = _(
                     "A filter for the target model %s is not valid.\n" "Details: %s"

--- a/mozaik_communication/models/distribution_list_line.py
+++ b/mozaik_communication/models/distribution_list_line.py
@@ -13,24 +13,6 @@ class DistributionListLine(models.Model):
     ]
     _unicity_keys = "N/A"
 
-    def _get_target_recordset(self):
-        """
-        For excluding filters the result is transformed
-        to exclude all target records linked
-        to the concerned partners
-        :return: target recordset
-        """
-        results = super()._get_target_recordset()
-        partner_path = self.mapped("distribution_list_id").partner_path
-        if results and all(self.mapped("exclude")) and partner_path:
-            partners = results.mapped(partner_path)
-            if partners:
-                domain = [
-                    (partner_path, "in", partners.ids),
-                ]
-                results = results.search(domain)
-        return results
-
     def action_show_filter_result_without_coordinate(self):
         """
         Show the result of the list without coordinate


### PR DESCRIPTION
In v8, there were several virtual.target records for 1 res.partner record, if this partner had several postal or mail coordinates. Hence to exclude a partner from the distribution list, we needed to exclude ALL virtual.target records linked to this partner.
In v14, there is only 1 virtual.target record for each res.partner record hence this code is not useful anymore.