### PR TITLE
[FIX] Partner is_address_duplicate_allowed migration

### DIFF
--- a/mozaik_person/migrations/14.0.1.0.0/post-migration.py
+++ b/mozaik_person/migrations/14.0.1.0.0/post-migration.py
@@ -9,3 +9,14 @@ def migrate(cr, version):
     cr.execute(
         "UPDATE res_partner SET identifier = identifier_moved0",
     )
+
+    _logger.info("Init is_address_duplicate_allowed from co_residency")
+
+    cr.execute(
+        """
+        UPDATE res_partner
+        SET is_address_duplicate_allowed_compute = true,
+            is_address_duplicate_allowed = true
+        WHERE co_residency_id IS NOT NULL
+        """
+    )


### PR DESCRIPTION
`is_address_duplicate_allowed_compute` and `is_address_duplicate_allowed` can not be computed properly if not initialized.

This is due to the fact that `field_allowed` is set to False if not True on both duplicates: https://github.com/mozaik-association/mozaik/blob/00262e81103857b13f7fa73c6234ccf6b72bff9d/mozaik_duplicate/models/abstract_duplicate.py#L254