### PR TITLE
[FIX] mozaik_address: two fields have the same label

### DIFF
--- a/mozaik_address/models/__init__.py
+++ b/mozaik_address/models/__init__.py
@@ -6,3 +6,4 @@ from . import res_city
 from . import address_address
 from . import co_residency
 from . import res_partner
+from . import res_users

--- a/mozaik_address/models/res_users.py
+++ b/mozaik_address/models/res_users.py
@@ -1,0 +1,17 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResUsers(models.Model):
+
+    _inherit = "res.users"
+
+    # Change field label because there is another field with the same
+    # label in HR module
+    address_address_id = fields.Many2one(
+        comodel_name="address.address",
+        string="Personal Address",
+        inherited=True,
+    )


### PR DESCRIPTION
Fields are address_address_id and address_home_id (HR module) on res.users