### PR TITLE
[RMV] mozaik_account: partner is not required for reconciliation process

### DIFF
--- a/mozaik_account/models/account_bank_statement_line.py
+++ b/mozaik_account/models/account_bank_statement_line.py
@@ -1,7 +1,6 @@
 # Copyright 2017 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import _, api, models
-from odoo.exceptions import ValidationError
+from odoo import api, models
 from odoo.fields import first
 from odoo.tools import float_compare
 
@@ -216,9 +215,6 @@ class AccountBankStatementLine(models.Model):
     def process_reconciliation(
         self, counterpart_aml_dicts=None, payment_aml_rec=None, new_aml_dicts=None
     ):
-        if self.filtered(lambda l: not l.partner_id):
-            raise ValidationError(_("You must first select a partner!"))
-
         for aml in new_aml_dicts:
             name = aml.get("name")
             if name:

--- a/mozaik_account/tests/test_accounting.py
+++ b/mozaik_account/tests/test_accounting.py
@@ -3,7 +3,6 @@
 import random
 import uuid
 
-from odoo.exceptions import ValidationError
 from odoo.fields import first
 from odoo.tests.common import SavepointCase
 
@@ -161,20 +160,6 @@ class TestAccounting(object):
             bank_s.line_ids.move_id,
             self.partner.membership_line_ids.move_id,
         )
-
-    def test_accounting_manual_reconcile_without_partner(self):
-        additional_amount = 1999.99
-        bank_s = self._generate_payment(
-            additional_amount=additional_amount, with_partner=False
-        )
-        bank_s.auto_reconcile()
-        for bank_st in bank_s:
-            for line in bank_st.line_ids:
-                self.assertFalse(line.is_reconciled)
-
-        move_dicts = self._get_manual_move_dict(additional_amount)
-        with self.assertRaises(ValidationError):
-            first(bank_s.line_ids).process_reconciliation(new_aml_dicts=move_dicts)
 
 
 class TestAccountingWithProduct(TestAccounting, SavepointCase):


### PR DESCRIPTION
This constraint is specific to Ecolo and will thus go in another module

refs #64337