### PR TITLE
[FIX] mozaik_membership_request: do not pass active_test=False in view, as it will stay

### DIFF
--- a/mozaik_membership_request/views/membership_request.xml
+++ b/mozaik_membership_request/views/membership_request.xml
@@ -56,14 +56,12 @@
                     <filter
                     name="state_validated"
                     string="Done"
-                    domain="[('state', '=', 'validate')]"
-                    context="{'active_test': False}"
+                    domain="[('state', '=', 'validate'), '|', ('active','=',False), ('active', '=', True)]"
                 />
                     <filter
                     name="state_cancelled"
                     string="Cancelled"
-                    domain="[('state', '=', 'cancel')]"
-                    context="{'active_test': False}"
+                    domain="[('state', '=', 'cancel'), '|', ('active','=',False), ('active', '=', True)]"
                 />
                     <separator />
                     <filter
@@ -76,8 +74,8 @@
                     <filter
                     name="all"
                     string="All"
-                    context="{'invisible_expire_date': False, 'active_test': False}"
-                    domain="[]"
+                    context="{'invisible_expire_date': False}"
+                    domain="['|', ('active','=',False), ('active', '=', True)]"
                     help="All Requests, expired or not"
                 />
                     <separator />


### PR DESCRIPTION
in context during the whole transaction