### PR TITLE
[CHG] Complete re-writing of mozaik membership request pre-process

### DIFF
--- a/mozaik_address/models/address_address.py
+++ b/mozaik_address/models/address_address.py
@@ -74,6 +74,7 @@ class AddressAddress(models.Model):
         string="Partners (inactive)",
         domain=[("active", "=", False)],
     )
+    has_street = fields.Boolean(compute="_compute_has_street")
 
     @api.model
     def _get_default_country_code(self):
@@ -239,3 +240,8 @@ class AddressAddress(models.Model):
             value = values[field] or "0"
             technical_value.append(format_value(value))
         return "#".join(technical_value)
+
+    @api.depends("street_man", "street2")
+    def _compute_has_street(self):
+        for address in self:
+            address.has_street = address.street_man or address.street2

--- a/mozaik_address_local_street/models/address_address.py
+++ b/mozaik_address_local_street/models/address_address.py
@@ -83,3 +83,9 @@ class AddressAddress(models.Model):
                 record.street_man = record.address_local_street_id.local_street
                 record.select_alternative_address_local_street = False
             record.street_man = False
+
+    @api.depends("street_man", "street2", "address_local_street_id")
+    def _compute_has_street(self):
+        super()._compute_has_street()
+        for address in self.filtered("address_local_street_id"):
+            address.has_street = True

--- a/mozaik_communication/models/membership_request.py
+++ b/mozaik_communication/models/membership_request.py
@@ -46,7 +46,7 @@ class MembershipRequest(models.Model):
                     )
                 )
 
-    def _partner_write_address(self, address_id, partner):
+    def _partner_write_address(self, address_id, partner, update_instance):
         """
         If the address is different from the partner's address,
         we set the postal bounce back to False.
@@ -55,10 +55,10 @@ class MembershipRequest(models.Model):
             partner
             and address_id
             and partner.address_address_id
-            and partner.address_address_id.id != address_id
+            and partner.address_address_id != address_id
         ):
             partner.write({"last_postal_failure_date": False})
-        super()._partner_write_address(address_id, partner)
+        super()._partner_write_address(address_id, partner, update_instance)
 
     def validate_request(self):
         """

--- a/mozaik_event_membership_request_involvement/models/membership_request.py
+++ b/mozaik_event_membership_request_involvement/models/membership_request.py
@@ -22,6 +22,17 @@ class MembershipRequest(models.Model):
             if record.event_registration_id:
                 record.force_autoval = record.event_registration_id.force_autoval
 
+    @api.model
+    def _find_lastname(self, vals):
+        """
+        For events, partner is given in 'associated_partner_id' field, not 'partner_id',
+        hence we give the partner inside the context.
+        """
+        res = super()._find_lastname(vals)
+        if self.env.context.get("mr_partner_id", False):
+            return True
+        return res
+
     def validate_request(self):
         """
         If the membership request is coming from an event registration

--- a/mozaik_membership_request/models/membership_request.py
+++ b/mozaik_membership_request/models/membership_request.py
@@ -1594,10 +1594,10 @@ class MembershipRequest(models.Model):
                         or partner.subscription_product_id.id,
                         "state_id": mr.result_type_id.id,
                     }
-                    if active_memberships.paid and active_memberships.price:
+                    if active_memberships.paid:
                         vals["price"] = 0
                     w = self.env["add.membership"].create(vals)
-                    if not (active_memberships.paid and active_memberships.price):
+                    if not active_memberships.paid:
                         w._onchange_product_id()  # compute the price
                 else:
                     w = self.env["add.membership"].create(

--- a/mozaik_membership_request/models/membership_request.py
+++ b/mozaik_membership_request/models/membership_request.py
@@ -186,9 +186,7 @@ class MembershipRequest(models.Model):
         tracking=True,
     )
 
-    address_id = fields.Many2one(
-        comodel_name="address.address", string="Current Address", tracking=True
-    )
+    address_id = fields.Many2one(comodel_name="address.address", string="Address")
     change_ids = fields.One2many(
         comodel_name="membership.request.change",
         inverse_name="membership_request_id",
@@ -259,6 +257,8 @@ class MembershipRequest(models.Model):
     nationality_id = fields.Many2one(
         comodel_name="res.country", string="Nationality", tracking=True
     )
+
+    is_pre_processed = fields.Boolean()
 
     @api.model
     def _get_status_values(self, request_type, date_from=False):
@@ -655,127 +655,51 @@ class MembershipRequest(models.Model):
                     if create_change:
                         chg_obj.create(vals)
 
-    @api.model
-    def _get_address_id(
-        self,
-        partner_id,
-        technical_name,
-        address_local_street_id,
-        street_man,
-        zip_man,
-        city_id,
-    ):
+    def _find_input_partner(self, vals):
         """
-        Search if the same address already exists, to avoid creating a new one.
-
-        Pay attention to the case where
-        * the address on the mr does not contain a street; AND
-         * the address on the partner does; AND
-        * the zipcode on the partner and on the mr are the same
-
-        because in this case, the address on the partner is more precise than on the mr,
-        and we do not want to erase it.
+        Find, if existing, the partner to add on the membership request,
+        and update lastname, firstname and email, if not given.
+        - If 'mr_partner_id' is a key of _context, then take the id given in the context
+        to associate the partner id and DON'T USE partner_id given in vals.
+        - If 'mr_partner_id' is not in the context, use field partner_id given in vals.
         """
-        address_id = (
-            self.env["address.address"]
-            .sudo()
-            .search([("technical_name", "=", technical_name)], limit=1)
-            .id
-        )
-        if partner_id and (zip_man or city_id):
-            partner = self.env["res.partner"].browse(partner_id)
-            partner_address_id = partner.address_address_id
-            zipcode = zip_man or self.env["res.city"].browse(city_id).zipcode
-            if (
-                partner_address_id
-                and partner_address_id.street
-                and not (address_local_street_id or street_man)
-                and (partner_address_id.zip == zipcode)
-            ):
-                address_id = False
+        # If the mr was already created (survey case), the partner may already
+        # be set on the mr.
+        partner = self.partner_id
+        if not partner and "mr_partner_id" in self._context:
+            mr_partner_id = self._context.get("mr_partner_id")
+            if mr_partner_id:
+                partner = self.env["res.partner"].browse(mr_partner_id)
+        elif not partner and vals.get("partner_id", False):
+            partner = self.env["res.partner"].browse(vals["partner_id"])
 
-        return address_id
+        if partner:
+            if "lastname" not in vals or not vals["lastname"]:
+                vals["lastname"] = partner.lastname
+            if ("firstname" not in vals or not vals["firstname"]) and partner.firstname:
+                vals["firstname"] = partner.firstname
+            if "email" not in vals or not vals["email"]:
+                vals["email"] = partner.email
+        return partner
 
-    @api.model
-    def _pre_process(self, vals):
+    def _find_or_create_address(self, vals):
         """
-        * Try:
-        ** to find a zipcode and a country
-        ** to build a birthdate_date
-        ** to find an existing partner
-        ** to find coordinates
+        Find address.address record if existing (based on technical name).
+        Create a new address.address record if not existing.
+        If no address is given (technical_name == EMPTY ADDRESS) return false.
 
-        :rparam vals: updated input values dictionary ready
-                      to create a ``membership_request``
+        :rparam technical_name: the computed technical name
+        :rparam address_id: the address_id, if already existing
+
         """
-        is_company = vals.get("is_company", False)
-        firstname = False if is_company else vals.get("firstname", False)
-        lastname = vals.get("lastname", False)
-        birthdate_date = False if is_company else vals.get("birthdate_date", False)
-        day = False if is_company else vals.get("day", False)
-        month = False if is_company else vals.get("month", False)
-        year = False if is_company else vals.get("year", False)
-        gender = False if is_company else vals.get("gender", False)
-        email = vals.get("email", False)
-        mobile = vals.get("mobile", False)
-        phone = vals.get("phone", False)
-        address_id = vals.get("address_id", False)
         address_local_street_id = vals.get("address_local_street_id", False)
         city_id = vals.get("city_id", False)
         number = vals.get("number", False)
         box = vals.get("box", False)
         city_man = vals.get("city_man", False)
-        country_id = vals.get("country_id", False)
-        zip_man = vals.get("zip_man", False)
         street_man = vals.get("street_man", False)
-
-        partner_id = vals.get("partner_id", False)
-
-        request_type = vals.get("request_type", False)
-
-        zids = False
-        if zip_man and city_man:
-            domain = [
-                ("zipcode", "=", zip_man),
-                ("name", "ilike", city_man),
-            ]
-            zids = self.env["res.city"].search(domain, limit=1)
-        if not zids and zip_man and not city_man and not country_id:
-            domain = [
-                ("zipcode", "=", zip_man),
-            ]
-            zids = self.env["res.city"].search(domain, limit=1)
-        if zids:
-            cnty_id = self.env["res.country"]._country_default_get("BE").id
-            if not country_id or cnty_id == country_id:
-                country_id = cnty_id
-                city_id = zids.id
-                city_man = False
-                zip_man = False
-
-        if not is_company and not birthdate_date:
-            birthdate_date = self.get_birthdate_date(day, month, year)
-        if mobile:
-            mobile = self.get_format_phone_number(mobile)
-        if phone:
-            phone = self.get_format_phone_number(phone)
-        if email:
-            email = self.get_format_email(email)
-
-        recognizable_values = {
-            "is_company": is_company,
-            "birthdate_date": birthdate_date,
-            "lastname": lastname,
-            "firstname": firstname,
-            "email": email,
-            "mobile": mobile,
-            "phone": phone,
-        }
-
-        if not partner_id:
-            partner = self.get_partner_id(recognizable_values)
-            if partner:
-                partner_id = partner.id
+        zip_man = vals.get("zip_man", False)
+        country_id = vals.get("country_id", False)
 
         technical_name = self.get_technical_name(
             address_local_street_id,
@@ -787,30 +711,209 @@ class MembershipRequest(models.Model):
             zip_man,
             country_id,
         )
-        address_id = address_id or self._get_address_id(
-            partner_id,
-            technical_name,
-            address_local_street_id,
-            street_man,
-            zip_man,
-            city_id,
+        if technical_name == EMPTY_ADDRESS:
+            return technical_name, False
+        existing_address = self.env["address.address"].search(
+            [("technical_name", "=", technical_name)], limit=1
         )
-        int_instance_id = self.get_int_instance_id(city_id)
+        if existing_address:
+            return technical_name, existing_address.id
+        else:
+            return (
+                technical_name,
+                self.env["address.address"]
+                .create(
+                    {
+                        "country_id": country_id,
+                        "street_man": street_man,
+                        "zip_man": zip_man,
+                        "city_man": city_man,
+                        "address_local_street_id": address_local_street_id,
+                        "city_id": city_id,
+                        "street2": vals.get("street2", False),
+                        "number": number,
+                        "box": box,
+                        "sequence": vals.get("sequence", False),
+                    }
+                )
+                .id,
+            )
 
-        res = self._onchange_partner_id_vals(
-            is_company, request_type, partner_id, technical_name
+    @api.model
+    def _manage_address_and_instance(self, vals, partner):
+        """
+        1. If address_id is given in vals: it is taken
+        2. Elif no partner is recognized: address (complete or partial) is always taken
+        3. Else, if
+          A. Partner has no address at all -> partial or complete address is always taken
+          B. Partner has an address -> it can be modified only by a
+            complete (with street) address
+
+        The instance is taken on the address if and only if the address from the MR is taken
+        """
+        values = {}
+        mr_address_id = vals.get("address_id", False)
+        if mr_address_id:
+            # 1.
+            address = self.env["address.address"].browse(mr_address_id)
+            values["address_id"] = mr_address_id
+            values["technical_name"] = (
+                self.env["address.address"].browse(mr_address_id).technical_name
+            )
+
+        else:
+            technical_name, address_id = self._find_or_create_address(vals)
+            address = (
+                self.env["address.address"].browse(address_id) if address_id else False
+            )
+            values["technical_name"] = technical_name
+            if not partner:
+                # 2.
+                values["address_id"] = address_id
+
+            else:
+                # 3.
+                if not partner.address_address_id:
+                    values["address_id"] = address_id
+                else:
+                    if address and address.has_street:
+                        values["address_id"] = address_id
+
+        # Manage instances
+        if values.get("address_id", False):
+            int_instance_id = self.get_int_instance_id(address.city_id.id)
+            values["int_instance_ids"] = [(4, int_instance_id)]
+        elif vals.get("int_instance_ids", False):
+            # If no address but an instance is given, take it
+            values["int_instance_ids"] = vals.get("int_instance_ids")
+
+        # Force instance must also be taken
+        values["force_int_instance_id"] = vals.get("force_int_instance_id", False)
+
+        return values
+
+    @api.model
+    def _pre_process(self, input_vals):  # noqa: C901
+        """
+        Try:
+        ** to find a zipcode and a country
+        ** to build a birthdate_date
+        ** to find an existing partner
+
+        :rparam output_vals: input values dictionary ready
+                      to create a ``membership_request``, built from input_vals input dict
+        """
+        partner = self._find_input_partner(input_vals)
+        partner_id = partner.id if partner else False
+        output_vals = {}
+        if "lastname" not in input_vals or not input_vals["lastname"]:
+            # No lastname -> not an interesting request, we do nothing
+            return input_vals
+
+        for key in ["lastname", "firstname"]:
+            val = input_vals.get(key, False)
+            if val:
+                input_vals[key] = val.strip().title()
+        is_company = input_vals.get("is_company", False)
+        lastname = input_vals.get("lastname", False)
+        firstname = False if is_company else input_vals.get("firstname", False)
+        request_type = input_vals.get("request_type", False)
+        email = input_vals.get("email", False)
+        phone = input_vals.get("phone", False)
+        mobile = input_vals.get("mobile", False)
+        birthdate_date = (
+            False if is_company else input_vals.get("birthdate_date", False)
         )
-        vals.update(res)
+        day = False if is_company else input_vals.get("day", False)
+        month = False if is_company else input_vals.get("month", False)
+        year = False if is_company else input_vals.get("year", False)
+        # It may happen that birthdate_date is given, but not day, month and year (coming from a
+        # survey for example). In this case fill the fields.
+        if birthdate_date and isinstance(birthdate_date, date):
+            day = birthdate_date.day
+            month = birthdate_date.month
+            year = birthdate_date.year
 
-        vals.update(
+        gender = False if is_company else input_vals.get("gender", False)
+
+        address_id = input_vals.get("address_id", False)
+        city_id = input_vals.get("city_id", False)
+        city_man = input_vals.get("city_man", False)
+        country_id = input_vals.get("country_id", False)
+        zip_man = input_vals.get("zip_man", False)
+
+        candidate_city = False
+        if not city_id and zip_man and city_man:
+            domain = [
+                ("zipcode", "=", zip_man),
+                ("name", "ilike", city_man),
+            ]
+            candidate_city = self.env["res.city"].search(domain, limit=1)
+        elif city_man and not city_id:
+            domain = [
+                ("name", "ilike", city_man),
+            ]
+            candidate_city = self.env["res.city"].search(domain, limit=2)
+            if len(candidate_city) != 1:
+                # Take the city only if it is unique
+                candidate_city = False
+        if (
+            not candidate_city
+            and not city_id
+            and zip_man
+            and not city_man
+            and not country_id
+        ):
+            domain = [
+                ("zipcode", "=", zip_man),
+            ]
+            candidate_city = self.env["res.city"].search(domain, limit=1)
+        if candidate_city:
+            be_country_id = self.env["res.country"]._country_default_get("BE").id
+            if not country_id or be_country_id == country_id:
+                # Default country is BE.
+                # In this case city_man and zip_man are reset to False
+                country_id = be_country_id
+                city_id = city_id or candidate_city.id
+                city_man = False
+                zip_man = False
+
+        # If city_id but no country, we now have to force the country
+        if city_id and not country_id:
+            country_id = self.env["res.city"].browse(city_id).country_id.id
+
+        if not is_company and not birthdate_date:
+            birthdate_date = self.get_birthdate_date(day, month, year)
+        if mobile:
+            mobile = self.get_format_phone_number(mobile)
+        if phone:
+            phone = self.get_format_phone_number(phone)
+        if email:
+            email = self.get_format_email(email)
+
+        # Try to recognize the partner, if not given in input_vals
+        if not partner:
+            recognizable_values = {
+                "is_company": is_company,
+                "birthdate_date": birthdate_date,
+                "lastname": lastname,
+                "firstname": firstname,
+                "email": email,
+                "mobile": mobile,
+                "phone": phone,
+            }
+            partner = self.get_partner_id(recognizable_values)
+            if partner:
+                partner_id = partner.id
+
+        output_vals.update(
             {
                 "is_company": is_company,
                 "partner_id": partner_id,
                 "lastname": lastname,
                 "firstname": firstname,
+                "request_type": request_type,
                 "birthdate_date": birthdate_date,
-                "int_instance_ids": res.get("int_instance_ids")
-                or [(6, 0, [int_instance_id])],
                 "day": day,
                 "month": month,
                 "year": year,
@@ -823,11 +926,37 @@ class MembershipRequest(models.Model):
                 "country_id": country_id,
                 "zip_man": zip_man,
                 "city_man": city_man,
-                "technical_name": technical_name,
             }
         )
+        # We now check all other keys from input_vals:
+        # if the key is not in output_vals and if it corresponds
+        # to a field from membership.request, we add it to output_vals
+        # It is useful to copy all other address fields.
+        for key in input_vals.keys():
+            if (
+                key not in output_vals
+                and key in self.env["membership.request"].fields_get()
+            ):
+                output_vals[key] = input_vals[key]
 
-        return vals
+        # Manage address and instances.
+        output_vals.update(self._manage_address_and_instance(output_vals, partner))
+
+        res = self._onchange_partner_id_vals(
+            is_company, request_type, partner_id, output_vals["technical_name"]
+        )
+        # Do not manage int_instance_ids separately from address in pre-process
+        res.pop("int_instance_ids", False)
+        output_vals.update(res)
+
+        # Finally manage int_instance: is partner is recognized and no int_instance is set
+        # (due to an address modification), take the partner's instance as a reminder on the MR.
+        if not output_vals.get("int_instance_ids", False) and partner:
+            output_vals["int_instance_ids"] = [(6, 0, partner.int_instance_ids.ids)]
+
+        output_vals["state"] = "confirm"
+        output_vals["is_pre_processed"] = True
+        return output_vals
 
     @api.onchange("country_id")
     def onchange_country_id(self):
@@ -1364,19 +1493,10 @@ class MembershipRequest(models.Model):
                 }
             )
 
-            # update_partner values
-            # Passing do_not_track_twice in context the first tracking
-            # evaluation through workflow will produce a notification
-            # the second one out of workflow not (when context will be
-            # pass through workflow this solution will not work anymore)
-            mr = mr.with_context(do_not_track_twice=True)  # TODO does nothing for now?
-            partner_obj = mr.env["res.partner"]  # we need to keep the modified context
-
             partner = mr.partner_id
-
             if not mr.partner_id:
                 mr._get_instance_partner(partner_values)
-                partner = partner_obj.create(partner_values)
+                partner = self.env["res.partner"].create(partner_values)
                 mr_vals["partner_id"] = partner.id
                 partner_values = {}
 
@@ -1387,104 +1507,87 @@ class MembershipRequest(models.Model):
 
             self._validate_request_coordinates(mr, partner_values)
 
+            # Before changing the membership, compute if address must be changed.
+            # If not, erase int_instance_ids, otherwise it will change the instance (without
+            # changing the address, which is unwanted).
+
+            # If the MR was pre-processed, we do not try to re-modify the address
+            if not mr.is_pre_processed:
+                address_vals = {
+                    "address_local_street_id": mr.address_local_street_id.id,
+                    "city_id": mr.city_id.id,
+                    "number": mr.number,
+                    "box": mr.box,
+                    "city_man": mr.city_man,
+                    "street_man": mr.street_man,
+                    "zip_man": mr.zip_man,
+                    "country_id": mr.country_id.id,
+                }
+                res_values = self._manage_address_and_instance(address_vals, partner)
+                mr.address_id = res_values.get("address_id", False)
+                mr.technical_name = res_values["technical_name"]
+            if not mr.address_id:
+                mr.int_instance_ids = [(6, 0, partner.int_instance_ids.ids)]
+
             if (
                 mr.result_type_id != mr.membership_state_id
-                or mr.force_int_instance_id != partner.int_instance_ids
-                or mr.int_instance_ids != partner.int_instance_ids
-            ):
-                mr._validate_request_membership(mr, partner)
-            # address if technical name is empty then means that no address
-            # required
-            mr.technical_name = mr.get_technical_name(
-                mr.address_local_street_id.id,
-                mr.city_id.id,
-                mr.number,
-                mr.box,
-                mr.city_man,
-                mr.street_man,
-                mr.zip_man,
-                mr.country_id.id,
-            )
-            mr.onchange_technical_name()
-            address_id = mr.address_id and mr.address_id.id or False
-            if (
-                not address_id
-                and mr.technical_name
-                and mr.technical_name != EMPTY_ADDRESS
-            ):
-                country_id = mr.country_id.id
-                street_man = False if mr.address_local_street_id else mr.street_man
-                zip_man = False if mr.city_id else mr.zip_man
-                city_man = False if mr.city_id else mr.city_man
-                address_local_street_id = (
-                    mr.address_local_street_id
-                    and mr.address_local_street_id.id
-                    or False
+                or (
+                    mr.force_int_instance_id
+                    and mr.force_int_instance_id != partner.int_instance_ids
                 )
-                city_id = mr.city_id and mr.city_id.id or False
-                street2 = mr.street2
-                number = mr.number
-                box = mr.box
-                sequence = mr.sequence
-                # Partner zip can only be changed if no address
-                # or street is also changed
-                if (
-                    not partner
-                    or not partner.address_address_id
-                    or (not zip_man and not city_id)
-                    or (zip_man or city_id and street_man or address_local_street_id)
-                ):
-                    address_id = self.env["address.address"].search(
-                        [
-                            ("country_id", "=", country_id),
-                            ("street_man", "=", street_man),
-                            ("zip_man", "=", zip_man),
-                            ("city_man", "=", city_man),
-                            ("address_local_street_id", "=", address_local_street_id),
-                            ("city_id", "=", city_id),
-                            ("street2", "=", street2),
-                            ("number", "=", number),
-                            ("box", "=", box),
-                        ],
-                        limit=1,
-                    )
-                    if not address_id:
-                        address_values = {
-                            "country_id": country_id,
-                            "street_man": street_man,
-                            "zip_man": zip_man,
-                            "city_man": city_man,
-                            "address_local_street_id": address_local_street_id,
-                            "city_id": city_id,
-                            "street2": street2,
-                            "number": number,
-                            "box": box,
-                            "sequence": sequence,
-                        }
-                        address_id = self.env["address.address"].create(address_values)
-                    mr_vals["address_id"] = address_id
-                    address_id = address_id.id
-            if address_id:
-                self._partner_write_address(address_id, partner)
+                or (
+                    mr.int_instance_ids
+                    and mr.int_instance_ids != partner.int_instance_ids
+                )
+            ):
+                # If partner is without_membership, no membership line exists on it,
+                # hence the force instance will not be modified.
+                mr._validate_request_membership(mr, partner)
+
+            if (
+                mr.result_type_id.code == "without_membership"
+                and mr.force_int_instance_id
+            ):
+                partner_values["force_int_instance_id"] = mr.force_int_instance_id
+
+            if mr.address_id:
+                # Write the address on the partner, and change the instance.
+                # Only case where the instance must NOT be changed:
+                # force instance is set
+                update_instance = not bool(mr.force_int_instance_id)
+                mr._partner_write_address(mr.address_id, partner, update_instance)
 
             if partner_values:
                 partner.write(partner_values)
 
-        # if request `validate` then object should be invalidate
+        # if request `validate` then object should be invalidated
         mr_vals.update({"state": "validate"})
 
         # superuser_id because of record rules
         self.sudo().action_invalidate(vals=mr_vals)
         return True
 
-    def _partner_write_address(self, address_id, partner):
+    def _partner_write_address(self, address_id, partner, update_instance):
         """
-        Write the address on the partner.
+        Write the address on the partner, only if it is a different one (otherwise trigger
+        unwanted logic, assuming that the address REALLY changes).
+        Use change address wizard.
+        It can happen that the address isn't linked to an instance
+        (if the address has no city_id). In this case don't update instance.
 
         Intended to be extended.
         """
-        if partner:
-            partner.write({"address_address_id": address_id})
+        if partner and (
+            not partner.address_address_id or partner.address_address_id != address_id
+        ):
+            wiz = self.env["change.address"].create(
+                {
+                    "address_id": address_id.id,
+                    "partner_ids": [(4, partner.id)],
+                    "update_instance": update_instance if address_id.city_id else False,
+                }
+            )
+            wiz.doit()
 
     @api.model
     def _validate_request_membership(self, mr, partner):
@@ -1694,10 +1797,11 @@ class MembershipRequest(models.Model):
             val = vals.get(key, False)
             if val:
                 vals[key] = val.strip().title()
-        if self.env.context.get("install_mode", False) or self.env.context.get(
-            "mode", True
-        ) in ["ws", "pre_process"]:
-            self._pre_process(vals)
+        if (
+            self.env.context.get("install_mode", False)
+            or self.env.context.get("mode", True) == "pre_process"
+        ):
+            vals = self._pre_process(vals)
 
         # do not pass related fields to the orm
         self._pop_related(vals)

--- a/mozaik_membership_request/views/membership_request.xml
+++ b/mozaik_membership_request/views/membership_request.xml
@@ -8,7 +8,6 @@
                 <search string="Membership Requests">
                     <field name="partner_id" />
                     <field name="int_instance_ids" />
-                    <field name="address_id" />
                     <field
                     string="Age >= ..."
                     name="age"
@@ -156,7 +155,7 @@
                     <field name="firstname" />
                     <field name="request_type" />
                     <field name="partner_id" />
-                    <field name="int_instance_ids" />
+                    <field name="int_instance_ids" widget="many2many_tags" />
                     <field name="is_company" />
                     <field name="state" />
 
@@ -443,13 +442,6 @@
                                 name="indexation_comments"
                                 attrs="{'invisible':[('is_company', '=', True)]}"
                             />
-                            </page>
-                            <page string="Coordinates" name="coordinates">
-                                <group>
-                                    <group>
-                                        <field name="address_id" readonly="1" />
-                                    </group>
-                                </group>
                             </page>
                             <page string="Payment" name="payment">
                                 <group>

--- a/mozaik_membership_request_autovalidate/tests/test_membership_request.py
+++ b/mozaik_membership_request_autovalidate/tests/test_membership_request.py
@@ -43,7 +43,7 @@ class TestMembershipRequest(TransactionCase):
         )
         mr._auto_validate(False)
         self.assertFalse(mr.partner_id)
-        self.assertEqual("draft", mr.state)
+        self.assertEqual("confirm", mr.state)
 
     def test_no_auto_val_no_email(self):
         """
@@ -64,7 +64,7 @@ class TestMembershipRequest(TransactionCase):
         )
         mr._auto_validate(True)
         self.assertFalse(mr.partner_id)
-        self.assertEqual("draft", mr.state)
+        self.assertEqual("confirm", mr.state)
 
     def test_auto_val_with_city_only(self):
         """
@@ -111,7 +111,7 @@ class TestMembershipRequest(TransactionCase):
         )
         mr._auto_validate(True)
         self.assertFalse(mr.partner_id)
-        self.assertEqual("draft", mr.state)
+        self.assertEqual("confirm", mr.state)
 
     def test_unrecognized_address(self):
         """
@@ -187,7 +187,7 @@ class TestMembershipRequest(TransactionCase):
         mr._auto_validate(True)
         self.assertTrue(mr.partner_id)
         self.assertEqual(thierry, mr.partner_id)
-        self.assertEqual("draft", mr.state)
+        self.assertEqual("confirm", mr.state)
 
     def test_no_autoval_email_not_unique(self):
         """
@@ -214,7 +214,7 @@ class TestMembershipRequest(TransactionCase):
             }
         )
         mr._auto_validate(True)
-        self.assertEqual("draft", mr.state)
+        self.assertEqual("confirm", mr.state)
 
     def test_no_autoeval_with_conflictual_status(self):
         marc = self.env["res.partner"].create(
@@ -246,7 +246,7 @@ class TestMembershipRequest(TransactionCase):
         mr.onchange_partner_component()
         mr._auto_validate(True)
         self.assertTrue(mr.partner_id)
-        self.assertEqual("draft", mr.state)
+        self.assertEqual("confirm", mr.state)
 
     def test_autoval_26993_2_4(self):
         """
@@ -269,7 +269,7 @@ class TestMembershipRequest(TransactionCase):
             {"lastname": "Dujardin", "firstname": "Jordan", "email": "jordan@duj.fr"}
         )
         self.assertEqual(self.federal, jordan.int_instance_id)
-        # We need to explicitely update the DB otherwise
+        # We need to explicitly update the DB otherwise
         # jordan.membership_state_id is not always correctly
         # set on virtual.partner
         jordan.flush()
@@ -314,7 +314,6 @@ class TestMembershipRequest(TransactionCase):
         mr._auto_validate(True)
         self.assertEqual("validate", mr.state)
         self.assertEqual(self.federal.id, jordan.int_instance_id.id)
-        self.assertTrue(mr.address_id)
 
         # Change Jordan's address in Huy, but keep federal instance
         grandplace5 = self.browse_ref("mozaik_address.address_1")

--- a/mozaik_membership_request_from_registration/models/membership_request.py
+++ b/mozaik_membership_request_from_registration/models/membership_request.py
@@ -21,160 +21,25 @@ class MembershipRequest(models.Model):
         for record in self:
             record.force_autoval = record.force_autoval
 
-    def _find_input_partner(self, vals):
-        """
-        Find, if existing, the partner to add on the membership request,
-        and update lastname, firstname and email, if not given.
-        - If 'mr_partner_id' is a key of _context, then take the id given in the context
-        to associate the partner id and DON'T USE partner_id given in vals.
-        - If 'mr_partner_id' is not in the context, use field partner_id given in vals.
-        """
-        # If the mr was already created (survey case), the partner may already
-        # be set on the mr.
-        partner = self.partner_id
-        if not partner and "mr_partner_id" in self._context:
-            mr_partner_id = self._context.get("mr_partner_id")
-            if mr_partner_id:
-                partner = self.env["res.partner"].browse(mr_partner_id)
-        elif not partner and "partner_id" in vals and vals["partner_id"]:
-            partner = self.env["res.partner"].browse(vals["partner_id"])
-
-        if partner:
-            if "lastname" not in vals or not vals["lastname"]:
-                vals["lastname"] = partner.lastname
-            if ("firstname" not in vals or not vals["firstname"]) and partner.firstname:
-                vals["firstname"] = partner.firstname
-            if "email" not in vals or not vals["email"]:
-                vals["email"] = partner.email
-        return partner
-
     @api.model
-    def _pre_process_values(self, vals):
+    def _find_lastname(self, vals):
         """
-        Pre-process values given in vals for creating the membership request.
-        Returns a dictionary of values.
+        Check if a lastname is given.
+        It can be given
+        * in vals, OR
+        * by partner_id in vals
+
+        (Intended to be extended for special AMA cases)
         """
-        partner = self._find_input_partner(vals)
-        values = {}
-        if "lastname" in vals and vals["lastname"]:
-            for key in ["lastname", "firstname"]:
-                val = vals.get(key, False)
-                if val:
-                    vals[key] = val.strip().title()
-            lastname = vals.get("lastname")
-            firstname = vals.get("firstname", False)
-            email = vals.get("email", False)
-            phone = vals.get("phone", False)
-            mobile = vals.get("mobile", False)
-            country_id = vals.get("country_id", False)
-            request_type = vals.get("request_type", False)
-
-            city_id = False
-            zip_man = False
-            # If zip is in vals: if it is recognized, we fill city_id
-            if "city_id" in vals:
-                city_id = vals["city_id"]
-            elif "zip" in vals and vals["zip"]:
-                candidate_city = self.env["res.city"].search(
-                    [("zipcode", "=", vals["zip"])], limit=1
-                )
-                if candidate_city and (
-                    not country_id or candidate_city.country_id.id == country_id
-                ):
-                    city_id = candidate_city.id
-                else:
-                    # In this case the zip was not automatically recognized,
-                    # or the country of the zip does not correspond to country_id.
-                    # Country is not set and zip is stored in zip_man.
-                    country_id = False
-                    zip_man = vals["zip"]
-            else:
-                country_id = False
-
-            # If city_id, we now have to force the country
-            if city_id and not country_id:
-                country_id = self.env["res.city"].browse(city_id).country_id.id
-
-            values = {}
-
-            if city_id:
-                # We do not want to get the default instance if
-                # no city is given
-                int_instance_id = self.get_int_instance_id(city_id)
-                values["int_instance_ids"] = [(4, int_instance_id)]
-
-            values.update(
-                {
-                    "lastname": lastname,
-                    "firstname": firstname,
-                    "email": email,
-                    "phone": phone,
-                    "mobile": mobile,
-                    "is_company": False,
-                    "request_type": request_type,
-                    "country_id": country_id,
-                    "city_id": city_id,
-                    "zip_man": zip_man,
-                    "effective_time": fields.datetime.now(),
-                    "state": "confirm",
-                }
-            )
-
-            # We know check all other keys from vals:
-            # if the key is not in values and if it corresponds
-            # to a field from membership.request, we add it to values
-            for key in vals.keys():
-                if (
-                    key not in values
-                    and key in self.env["membership.request"].fields_get()
-                ):
-                    values[key] = vals[key]
-
-            # If a partner is given in vals, we do not change it
-            if not partner:
-                recognizable_values = {
-                    "is_company": False,
-                    "birthdate_date": False,
-                    "lastname": lastname,
-                    "firstname": firstname,
-                    "email": email,
-                    "mobile": mobile,
-                    "phone": phone,
-                }
-                partner = self.get_partner_id(recognizable_values)
-            values.update({"partner_id": partner.id if partner else False})
-            # 26993/2.4.2.1.2
-            # If the partner has no address but a membership state,
-            # we force the instance to be the one of the partner.
-            if partner and values["city_id"]:
-                if not partner.address_address_id:
-                    if partner.membership_state_id.code != "without_membership":
-                        # 26993/2.4.2.1.2
-                        values.update(
-                            {"force_int_instance_id": partner.int_instance_ids[0].id}
-                        )
-                elif partner.address_address_id.city_id.id == values["city_id"]:
-                    # 26993/2.4.2.2.1
-                    values.update(
-                        {
-                            "country_id": False,
-                            "city_id": False,
-                            "force_int_instance_id": partner.int_instance_ids[0].id,
-                        }
-                    )
-        return values
+        return vals.get("lastname", False) or vals.get("partner_id", False)
 
     def _create_membership_request(self, vals):
-        values = self._pre_process_values(vals)
-        if bool(values):
-            request = self.with_context(mode="pre_process").create(values)
-            res = request._onchange_partner_id_vals(
-                is_company=values["is_company"],
-                request_type=values["request_type"],
-                partner_id=values["partner_id"],
-                technical_name=False,
-            )
-            request.write(res)
+        #  If 'zip' is given in vals (as coming from an event for example),
+        #  add it also in zip_man
+        if "zip" in vals and "zip_man" not in vals:
+            vals["zip_man"] = vals["zip"]
+        if self._find_lastname(vals):
+            request = self.with_context(mode="pre_process").create(vals)
             return request
 
     def _auto_validate_may_be_forced(self, auto_validate):

--- a/mozaik_survey_membership_request_involvement/controllers/main.py
+++ b/mozaik_survey_membership_request_involvement/controllers/main.py
@@ -40,9 +40,6 @@ class SurveyMembershipRequest(Survey):
             answer = user_input_line._get_answer()
             values.update({user_input_line.question_id.bridge_field_id.name: answer})
 
-        # update zip_man -> zip to fit with mozaik_membership_request_from_registration
-        values["zip"] = values.pop("zip_man", False)
-
         # If no lastname is given in the bridge field, either the partner_id was
         # specified, or we are still with UNKNOWN_PERSON
         # In both cases we want to update the membership request, so we fill "lastname"
@@ -50,7 +47,7 @@ class SurveyMembershipRequest(Survey):
             values.pop("lastname", False) or membership_request.lastname
         )
 
-        values = membership_request._pre_process_values(values)
+        values = membership_request._pre_process(values)
         membership_request.write(values)
 
         res = membership_request._onchange_partner_id_vals(


### PR DESCRIPTION
Significant changes to mozaik membership requests pre-process and validation:

1. Use the same pre-process method for MR coming from an AMA object (event, petition, survey) and for MR coming from REST services.

3. Fix some bugs coming at validation of the request, linked to addresses and instances, and modify the behavior (in accordance with the clients) to be more consistent.
* Concerning the instances:
o     The instance is modified if and only if the address is.
o If a force instance is given, it is always taken into account.
* Concerning the addresses: 
o A complete address (with a street) will always be written on the partner.
o A partial address (with city but without street) will be written on the partner only if we had no address before.

3. Fix some other bugs, such as:
* When opening all MR of a partner, do not pass `active_test=False` in context, as we do not want to keep it in all further actions, on all models.
* When changing partner's instance, the new membership line must be marked as paid if the previous one, still active, was.
* When trying to recognize an existing partner, search directly on `res.partner` and not on `virtual.custom.partner`anymore (makes no sense as it excluded partners having no email and no postal address, which is unwanted)
