### PR TITLE
14.0 65136 mozaik membership request email matching mle

### DIFF
--- a/mozaik_membership_request/models/membership_request.py
+++ b/mozaik_membership_request/models/membership_request.py
@@ -1474,6 +1474,21 @@ class MembershipRequest(models.Model):
                 partner = self.env["res.partner"].create(partner_values)
                 mr_vals["partner_id"] = partner.id
                 partner_values = {}
+            else:
+                # Do not update firstname and lastname if the only modifications
+                # are upper/lower case changes
+                if (
+                    partner.lastname
+                    and mr.lastname
+                    and partner.lastname.lower() == mr.lastname.lower()
+                ):
+                    partner_values.pop("lastname", False)
+                if (
+                    partner.firstname
+                    and mr.firstname
+                    and partner.firstname.lower() == mr.firstname.lower()
+                ):
+                    partner_values.pop("firstname", False)
 
             # create new involvements
             self._validate_request_involvement(mr, partner)

--- a/mozaik_membership_request/models/membership_request.py
+++ b/mozaik_membership_request/models/membership_request.py
@@ -1732,8 +1732,10 @@ class MembershipRequest(models.Model):
 
     @api.model
     def _validate_request_coordinates(self, mr, partner_values):
-        # case of email
-        if mr.email:
+        # case of email: do not change email if only difference is lower/upper case
+        if mr.email and (
+            not mr.partner_id.email or mr.email.lower() != mr.partner_id.email.lower()
+        ):
             partner_values["email"] = mr.email
         # case of phone
         if mr.phone:

--- a/mozaik_membership_request/models/membership_request.py
+++ b/mozaik_membership_request/models/membership_request.py
@@ -1286,9 +1286,9 @@ class MembershipRequest(models.Model):
                 "[('membership_state_id', '!=', False),"
                 "('is_company', '=', False),"
                 "('birthdate_date','=', '%s'),"
-                "('email', '=', '%s'),"
-                "('firstname', 'ilike', \"%s\"),"
-                "('lastname', 'ilike', \"%s\")]"
+                "('email', '=ilike', '%s'),"
+                "('firstname', '=ilike', \"%s\"),"
+                "('lastname', '=ilike', \"%s\")]"
                 % (birthdate_date, email, firstname, lastname)
             )
         if not is_company and birthdate_date and email:
@@ -1296,44 +1296,44 @@ class MembershipRequest(models.Model):
                 "[('membership_state_id', '!=', False),"
                 "('is_company', '=', False),"
                 "('birthdate_date','=', '%s'),"
-                "('email', '=', '%s')]" % (birthdate_date, email)
+                "('email', '=ilike', '%s')]" % (birthdate_date, email)
             )
         if not is_company and email and firstname and lastname:
             partner_domains.append(
                 "[('membership_state_id', '!=', False),"
                 "('is_company', '=', False),"
-                "('email', '=', '%s'),"
-                "('firstname', 'ilike', \"%s\"),"
-                "('lastname', 'ilike', \"%s\")]" % (email, firstname, lastname)
+                "('email', '=ilike', '%s'),"
+                "('firstname', '=ilike', \"%s\"),"
+                "('lastname', '=ilike', \"%s\")]" % (email, firstname, lastname)
             )
         if not is_company and email:
             partner_domains.append(
                 "[('membership_state_id', '!=', False),"
                 "('is_company', '=', False),"
-                "('email', '=','%s')]" % (email)
+                "('email', '=ilike','%s')]" % (email)
             )
         if is_company and email:
             partner_domains.append(
-                "[('is_company', '=', True)," "('email', '=','%s')]" % (email)
+                "[('is_company', '=', True)," "('email', '=ilike','%s')]" % (email)
             )
         if lastname:
             if not is_company and firstname:
                 partner_domains.append(
                     "[('membership_state_id','!=',False),"
                     "('is_company', '=', False),"
-                    "('firstname', 'ilike', \"%s\"),"
-                    "('lastname', 'ilike', \"%s\")]" % (firstname, lastname)
+                    "('firstname', '=ilike', \"%s\"),"
+                    "('lastname', '=ilike', \"%s\")]" % (firstname, lastname)
                 )
             elif not is_company:
                 partner_domains.append(
                     "[('membership_state_id', '!=', False),"
                     "('is_company', '=', False),"
-                    '("lastname", \'ilike\', "%s")]' % (lastname)
+                    "('lastname', '=ilike', \"%s\")]" % (lastname)
                 )
             else:
                 partner_domains.append(
                     "[('is_company', '=', True),"
-                    "('lastname', 'ilike', \"%s\")]" % (lastname)
+                    "('lastname', '=ilike', \"%s\")]" % (lastname)
                 )
         return partner_domains
 

--- a/mozaik_membership_request/tests/test_membership_request.py
+++ b/mozaik_membership_request/tests/test_membership_request.py
@@ -865,6 +865,24 @@ class TestMembership(TransactionCase):
         mr2.onchange_partner_component()
         self.assertEqual(mr2.partner_id, hermione)
 
+    def test_validate_request_and_write_firstname_lastname(self):
+        """
+        Create a membership request linked to an existing partner. Change firstname and lastname
+        (but only some capital letters).
+        -> When validating the MR, no change was done
+        """
+        emilie = self.env["res.partner"].create(
+            {"lastname": "Dupuis", "firstname": "Emilie"}
+        )
+        mr = self.env["membership.request"].create(
+            {"lastname": "Dupuis", "firstname": "Emilie", "partner_id": emilie.id}
+        )
+        # must remove capital letters in write because there is a check in the create method
+        mr.write({"lastname": "dupuis", "firstname": "emilie"})
+        mr.validate_request()
+        self.assertEqual(emilie.firstname, "Emilie")
+        self.assertEqual(emilie.lastname, "Dupuis")
+
     def test_validate_request_and_write_email(self):
         """
         When validating the membership request:

--- a/mozaik_membership_request_autovalidate/models/membership_request.py
+++ b/mozaik_membership_request_autovalidate/models/membership_request.py
@@ -89,13 +89,23 @@ class MembershipRequest(models.Model):
 
         # 26993/2.3.2 (second part)
         if auto_val and self.partner_id:
-            # for existing partner, names must be equal
+            # for existing partner, names must be equal (ignore upper/lower letter changes)
+            lower_mr_firstname = self.firstname and self.firstname.lower()
+            lower_partner_firstname = (
+                self.partner_id.firstname and self.partner_id.firstname.lower()
+            )
+            lower_mr_lastname = self.lastname and self.lastname.lower()
+            lower_partner_lastname = (
+                self.partner_id.lastname and self.partner_id.lastname.lower()
+            )
             auto_val = (
-                self.partner_id.firstname == self.firstname
-                and self.partner_id.lastname == self.lastname
+                lower_partner_lastname == lower_mr_lastname
+                and lower_partner_firstname == lower_mr_firstname
             )
             if not auto_val:
-                failure_reason = _("Firstname and lastname do not correspond")
+                failure_reason = _(
+                    "Firstname and lastname do not correspond (case insensitive check)"
+                )
 
         if auto_val:
             auto_val, failure_reason = self._check_auto_validation_with_emails(auto_val)

--- a/mozaik_membership_request_sensitive_data/models/membership_request.py
+++ b/mozaik_membership_request_sensitive_data/models/membership_request.py
@@ -149,7 +149,7 @@ class MembershipRequest(models.Model):
                         # Just formatting phone/mobile number is
                         # not considered as a sensitive change
                         if (
-                            key not in ["lastname", "firstname"]
+                            key not in ["lastname", "firstname", "email"]
                             or mr_value.lower() != partner_value.lower()
                         ):
                             # Just changing lower/upper letters is not a sensitive change


### PR DESCRIPTION
Ticket 65136: On ignore les majuscules lors du contrôle d'unicité des mails dans Odoo
Ticket 65169: Ne pas bloquer l'autovalidation quand le nom/prénom est similaire à des majuscules près
