### PR TITLE
[ADD] mozaik_email_lowered: mixin adding a new field 'lowered_email'

### DIFF
--- a/mozaik_all/__manifest__.py
+++ b/mozaik_all/__manifest__.py
@@ -28,6 +28,7 @@
         "mozaik_committee",
         "mozaik_duplicate",
         "mozaik_dynamical_time_filter",
+        "mozaik_email_lowered",
         "mozaik_event_chatter",
         "mozaik_event_description",
         "mozaik_event_export",

--- a/mozaik_email_lowered/__init__.py
+++ b/mozaik_email_lowered/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mozaik_email_lowered/__manifest__.py
+++ b/mozaik_email_lowered/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2023 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Mozaik Email Lowered",
+    "summary": """
+        Adds a compute fields keeping lowered email (lowered and stripped).
+        Implements a search on lowered email when searching on email.""",
+    "version": "14.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "ACSONE SA/NV",
+    "website": "https://github.com/mozaik-association/mozaik",
+    "depends": [
+        "base",
+        "mozaik_tools",
+    ],
+    "data": [],
+    "demo": [],
+}

--- a/mozaik_email_lowered/models/__init__.py
+++ b/mozaik_email_lowered/models/__init__.py
@@ -1,0 +1,2 @@
+from . import lowered_email_mixin
+from . import res_partner

--- a/mozaik_email_lowered/models/lowered_email_mixin.py
+++ b/mozaik_email_lowered/models/lowered_email_mixin.py
@@ -1,0 +1,41 @@
+# Copyright 2023 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+from odoo.addons.mozaik_tools.tools import format_email
+
+
+class MozaikLoweredEmailMixin(models.AbstractModel):
+
+    _name = "mozaik.lowered.email.mixin"
+    _description = "Mozaik Lowered Email Mixin"
+
+    email = fields.Char()
+    lowered_email = fields.Char(compute="_compute_lowered_email", store=True)
+
+    @api.depends("email")
+    def _compute_lowered_email(self):
+        for rec in self:
+            rec.lowered_email = format_email(rec.email) if rec.email else False
+
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        """
+        When searching with '=ilike' on emails, search with '=' on
+        lowered_email
+        """
+        new_args = []
+        for arg in args:
+            if (
+                isinstance(arg, (list, tuple))
+                and arg[0] == "email"
+                and arg[1] == "=ilike"
+                and isinstance(arg[2], str)
+            ):
+                search_field_name = "lowered_email"
+                operator = "="
+                value = format_email(arg[2])
+                new_args.append((search_field_name, operator, value))
+            else:
+                new_args.append(arg)
+        return super().search(new_args, offset, limit, order, count)

--- a/mozaik_email_lowered/models/res_partner.py
+++ b/mozaik_email_lowered/models/res_partner.py
@@ -1,0 +1,10 @@
+# Copyright 2023 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ResPartner(models.Model):
+
+    _name = "res.partner"
+    _inherit = ["res.partner", "mozaik.lowered.email.mixin"]

--- a/mozaik_email_lowered/tests/__init__.py
+++ b/mozaik_email_lowered/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_partner

--- a/mozaik_email_lowered/tests/test_res_partner.py
+++ b/mozaik_email_lowered/tests/test_res_partner.py
@@ -1,0 +1,25 @@
+# Copyright 2023 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.tests.common import TransactionCase
+
+
+class TestPartner(TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_find_email_with_underscore(self):
+        """
+        When using 'ilike' in search method, _ is not escaped.
+        But when using '=ilike' in search method, _ is escaped
+        and considered as a normal character.
+        """
+        self.env["res.partner"].create({"name": "Omar Sy", "email": "omar.sy@test.com"})
+        self.env["res.partner"].create({"name": "Omar Sy", "email": "omar_sy@test.com"})
+
+        res = self.env["res.partner"].search([("email", "ilike", "omar.sy")])
+        self.assertEqual(len(res), 1)
+        res = self.env["res.partner"].search([("email", "ilike", "omar_sy")])
+        self.assertEqual(len(res), 2)
+
+        res = self.env["res.partner"].search([("email", "=ilike", "omar_sy@test.com")])
+        self.assertEqual(len(res), 1)

--- a/mozaik_membership_request/__manifest__.py
+++ b/mozaik_membership_request/__manifest__.py
@@ -19,6 +19,7 @@
         "mozaik_tools",
         "mozaik_account",
         "statechart",
+        "mozaik_email_lowered",
         # 'mozaik_involvement',
     ],
     "data": [

--- a/mozaik_membership_request/models/membership_request.py
+++ b/mozaik_membership_request/models/membership_request.py
@@ -77,7 +77,7 @@ def partner_add_values(mr, partner_values):
 class MembershipRequest(models.Model):
 
     _name = "membership.request"
-    _inherit = ["mozaik.abstract.model"]
+    _inherit = ["mozaik.abstract.model", "mozaik.lowered.email.mixin"]
     _description = "Membership Request"
     _inactive_cascade = True
     _terms = ["interest_ids", "competency_ids"]

--- a/setup/mozaik_email_lowered/odoo/addons/mozaik_email_lowered
+++ b/setup/mozaik_email_lowered/odoo/addons/mozaik_email_lowered
@@ -1,0 +1,1 @@
+../../../../mozaik_email_lowered

--- a/setup/mozaik_email_lowered/setup.py
+++ b/setup/mozaik_email_lowered/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This allows to transform searches with domain tuple ('email', '=ilike', value) into domain tuple ('lowered_email', '=', value) hence special characters such as % and _ are escaped.

refs #65665