### PR TITLE
[14.0][IMP] mozaik_communication: add forwarding error recipients

### DIFF
--- a/mozaik_communication/__manifest__.py
+++ b/mozaik_communication/__manifest__.py
@@ -32,6 +32,7 @@
         "email_template_configurator",
     ],
     "data": [
+        "data/ir_config_parameter.xml",
         "views/membership_request.xml",
         "security/communication_security.xml",
         "security/ir.model.access.csv",

--- a/mozaik_communication/data/ir_config_parameter.xml
+++ b/mozaik_communication/data/ir_config_parameter.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <record id="communication_forwarding_error_recipient" model="ir.config_parameter">
+        <field name="key">communication.forwarding_error_recipient_ids</field>
+        <field name="value" />
+    </record>
+</odoo>

--- a/mozaik_communication/models/distribution_list.py
+++ b/mozaik_communication/models/distribution_list.py
@@ -184,12 +184,20 @@ class DistributionList(models.Model):
             "<p>Sender: %s</p>"
             "<p>Failure Reason: %s</p>"
         ) % (name, email_from, reason)
+        recipient_ids = self.res_users_ids.mapped("partner_id").ids
+        extra_recipient_ids = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("communication.forwarding_error_recipient_ids")
+        )
+        if extra_recipient_ids:
+            recipient_ids += [
+                int(i) for i in extra_recipient_ids.replace(" ", "").split(",") if i
+            ]
         vals = {
             "parent_id": False,
             "use_active_domain": False,
-            "partner_ids": [
-                (6, 0, self.res_users_ids.mapped("partner_id").ids),
-            ],
+            "partner_ids": [(6, 0, recipient_ids)],
             "notify": False,
             "model": self._name,
             "record_name": self.name,


### PR DESCRIPTION
Add recipients (from param system) to the email sent when forwarding to distribution list fails.