### PR TITLE
[FIX] mozaik_sponsorship: sponsoring a member candidate

### DIFF
--- a/mozaik_sponsorship/models/membership_request.py
+++ b/mozaik_sponsorship/models/membership_request.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class MembershipRequest(models.Model):
@@ -10,6 +11,12 @@ class MembershipRequest(models.Model):
 
     can_be_sponsored = fields.Boolean(compute="_compute_can_be_sponsored")
     sponsor_id = fields.Many2one("res.partner")
+
+    @api.constrains("sponsor_id", "partner_id")
+    def check_parent_different_from_self(self):
+        for mr in self:
+            if mr.sponsor_id and mr.sponsor_id == mr.partner_id:
+                raise ValidationError(_("A partner cannot be sponsored by itself"))
 
     @api.depends("partner_id", "partner_id.membership_state_id")
     def _compute_can_be_sponsored(self):

--- a/mozaik_sponsorship/models/res_partner.py
+++ b/mozaik_sponsorship/models/res_partner.py
@@ -1,7 +1,8 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
@@ -15,3 +16,9 @@ class ResPartner(models.Model):
         string="Sponsor Godchildren",
         domain=[("active", "=", True)],
     )
+
+    @api.constrains("sponsor_id")
+    def check_parent_different_from_self(self):
+        for rec in self:
+            if rec.sponsor_id == rec:
+                raise ValidationError(_("A partner cannot be sponsored by itself"))


### PR DESCRIPTION
When validating the MR, if the partner already has an active membership line
in the same state as the MR result state, we do not create a new membership
line, but we update the existing one (update price, product and reference).

The problem is that we update the price only if it is > 0
(We cannot update a price = 0 otherwise every MR will modify existing
membership lines, even if they don't intend to do it, as 0 is the default value).
But sponsored memberships are likely to involve free membership products.

Hence, in the special sponsorship context (if sponsor_id is filled on the MR),
we allow to modify the price and the product. We search for the corresponding
product based on membership tarification rules. We thus ignore the amount
that could have been added on the membership request.