### PR TITLE
[FIX] mozaik_sponsorship: sponsored membership but partner wants to pay more

### DIFF
--- a/mozaik_membership_request/wizards/add_membership.py
+++ b/mozaik_membership_request/wizards/add_membership.py
@@ -1,6 +1,5 @@
 # Copyright 2023 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-import json
 
 from odoo import models
 
@@ -11,29 +10,5 @@ class AddMembership(models.TransientModel):
 
     def _create_membership_line(self, reference=None):
         res = super()._create_membership_line(reference)
-
-        # The statechart is defined but lives independently of the record
-        # This was not the best way to do that when migrating but
-        # to avoid refactoring the whole code, we force the configuration,
-        # setting the current membership state to trigger the right
-        # computation of sc_<event>_allowed fields.
-        self.sudo().partner_id.sc_state = json.dumps(
-            {"configuration": ["root", self.partner_id.membership_state_id.code]}
-        )
-
-        if (
-            self.product_id.advance_workflow_as_paid
-            and self.partner_id.sc_paid_allowed
-            and res.price == 0
-            and res.paid
-        ):
-            # If creating a free membership line, we want to trigger the
-            # same workflow as when a not free membership line is marked as paid,
-            # i.e. creating the following membership (following the statechart)
-            next_state = self.partner_id.simulate_next_state(event="paid")
-            status_obj = self.env["membership.state"]
-            status = status_obj.search([("code", "=", next_state)], limit=1)
-            if res.state_id != status:
-                res.create_following_membership(status)
-
+        res._advance_in_workflow()
         return res

--- a/mozaik_sponsorship/__manifest__.py
+++ b/mozaik_sponsorship/__manifest__.py
@@ -18,6 +18,7 @@
     "data": [
         "views/res_partner.xml",
         "views/membership_request.xml",
+        "views/membership_line.xml",
     ],
     "demo": [],
 }

--- a/mozaik_sponsorship/models/__init__.py
+++ b/mozaik_sponsorship/models/__init__.py
@@ -1,2 +1,3 @@
 from . import res_partner
 from . import membership_request
+from . import membership_line

--- a/mozaik_sponsorship/models/membership_line.py
+++ b/mozaik_sponsorship/models/membership_line.py
@@ -1,0 +1,11 @@
+# Copyright 2023 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class MembershipLine(models.Model):
+
+    _inherit = "membership.line"
+
+    is_sponsored = fields.Boolean(copy=False)

--- a/mozaik_sponsorship/tests/test_membership_request.py
+++ b/mozaik_sponsorship/tests/test_membership_request.py
@@ -182,6 +182,7 @@ class TestMembershipRequest(SavepointCase):
         self.assertTrue(not_active_line.paid)
         self.assertEqual(active_line.price, 0)
         self.assertEqual(not_active_line.price, 0)
+        self.assertTrue(active_line.is_sponsored)
 
         self.assertEqual(self.harry.sponsor_id, self.ron)
 
@@ -239,6 +240,7 @@ class TestMembershipRequest(SavepointCase):
         self.assertEqual(not_active_line.state_id.code, "member_candidate")
         self.assertEqual(not_active_line.price, 0)
         self.assertEqual(not_active_line.product_id, self.product_sponsored)
+        self.assertTrue(active_line.is_sponsored)
 
     def test_sponsored_membership_not_member_wants_to_pay(self):
         """
@@ -281,5 +283,6 @@ class TestMembershipRequest(SavepointCase):
         self.assertFalse(active_line.paid)
         self.assertEqual(active_line.price, 8)
         self.assertEqual(active_line.product_id, self.product_sponsored)
+        self.assertTrue(active_line.is_sponsored)
 
         self.assertEqual(self.harry.sponsor_id, self.ron)

--- a/mozaik_sponsorship/views/membership_line.xml
+++ b/mozaik_sponsorship/views/membership_line.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="membership_line_form_view">
+        <field name="name">membership.line.form (in mozaik_sponsorship)</field>
+        <field name="model">membership.line</field>
+        <field name="inherit_id" ref="mozaik_membership.membership_line_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='info']" position="inside">
+                <group name="sponsor">
+                    <group>
+                        <field name="is_sponsored" />
+                    </group>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="membership_line_tree_view">
+        <field name="name">membership.line.tree (in mozaik_sponsorship)</field>
+        <field name="model">membership.line</field>
+        <field name="inherit_id" ref="mozaik_membership.membership_line_tree_view" />
+        <field name="arch" type="xml">
+            <field name="date_to" position="after">
+                <field name="is_sponsored" optional="hide" />
+            </field>
+        </field>
+    </record>
+
+
+
+</odoo>


### PR DESCRIPTION
Fix special cases: 

* New member is sponsored, but he wants to pay his membership: the mozaik workflow created the membership line with the default product price (here 0 for a sponsored membership), and then modified the price (to copy the price of the MR) afterwards. But for sponsored memberships, `advance_workflow_as_paid` is  True on the product, hence the membership line was marked as paid and the workflow continued before changing the ML price. The result was a paid membership line but already marked as paid. 

* Existing member candidate now became sponsored. The MR sets his sponsor and the price is then 0. We overrode the `_validate_request_membership` method in `mozaik_sponsorship` but it was dealing with all active ML, even if the partner wasn't a member candidate before. The problem is that we recognized the sponsored product on basis of the price, and we set back the default price. But when we modified the default price by setting it in the MR, it was undone.
-> The `_validate_request_membership` overwritting must only be used for existing ML.

* When modifying the price of an existing membership line, trigger the workflow if the member candidate line price became 0 (because the ML is thus now paid)

Add a boolean `is_sponsored` on membership lines
This checkbox will be True on the active ML after validating the MR (hence not the member candidate line, but the following one).