### PR TITLE
[FIX] mozaik_membership_request: computing the price of the ML when partner was in a free state

### DIFF
--- a/mozaik_membership_request/models/membership_request.py
+++ b/mozaik_membership_request/models/membership_request.py
@@ -1626,8 +1626,11 @@ class MembershipRequest(models.Model):
                     ):
                         # If we were in a free state, it is marked as paid by default, but
                         # the next paid membership must not be marked as paid (without
-                        # registering a payment).
-                        w._onchange_product_id()  # compute the price
+                        # registering a payment). Compute the price (on the product or
+                        # on the MR if set).
+                        w._onchange_product_id()
+                        if self.amount:
+                            w.price = self.amount
                 else:
                     w = self.env["add.membership"].create(
                         {


### PR DESCRIPTION
When partner was in a free state, the default Mozaik behavior was to create the following ML with a null price. This caused problems for e.g. for supporters becoming members. There was a first fix to trigger the product onchange to get the price of the product on the ML before creating it. But this fix wasn't completely working: when the price was overwritten on the MR, we forgot to update it in the ML creation vals. This fix thus also deals with this special case.

refs #67035