### PR TITLE
[IMP] mozaik_committee: add partner_id_domain on candidatures.

### DIFF
--- a/mozaik_committee/__manifest__.py
+++ b/mozaik_committee/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "AGPL-3",
     "author": "ACSONE SA/NV",
     "website": "https://github.com/mozaik-association/mozaik",
-    "depends": ["mozaik_mandate", "statechart"],
+    "depends": ["mozaik_mandate", "statechart", "web_domain_field"],
     "data": [
         "security/groups.xml",
         "security/ir.model.access.csv",

--- a/mozaik_committee/views/abstract_candidature.xml
+++ b/mozaik_committee/views/abstract_candidature.xml
@@ -64,9 +64,10 @@
                                 class="oe_inline"
                                 readonly="1"
                             /></h1>
-                        <h2><field
+                        <h2><field name="partner_id_domain" invisible="1" />
+                            <field
                                 name="partner_id"
-                                domain="[('is_company','=',False)]"
+                                domain="partner_id_domain"
                                 attrs="{'readonly': [('id','!=',False)]}"
                                 context="{'default_is_company': False}"
                             /></h2>


### PR DESCRIPTION
Goal is to limit to partners having an instance child of the instance of the selection committee

refs #67284