### PR TITLE
 [CHG] MR validation: change address before changing the membership state.

### DIFF
--- a/mozaik_membership_last_changes_report/models/membership_line.py
+++ b/mozaik_membership_last_changes_report/models/membership_line.py
@@ -11,7 +11,7 @@ class MembershipLine(models.Model):
     last_changes = fields.Text(copy=False)
     last_changes_sequence = fields.Integer(
         string="Change Sequence", index=True, copy=False, default=999
-    )  # TODO: mig script for Ecolo, as field name changed
+    )
 
     @api.model
     def create(self, vals):

--- a/mozaik_membership_last_changes_report/models/res_partner.py
+++ b/mozaik_membership_last_changes_report/models/res_partner.py
@@ -241,7 +241,7 @@ class ResPartner(models.Model):
                     "national_voluntary" in vals,
                 ]
             ):
-                change = self._get_voluntary_change(  # TODO
+                change = self._get_voluntary_change(
                     vals.get("local_voluntary"),
                     vals.get("regional_voluntary"),
                     vals.get("national_voluntary"),

--- a/mozaik_membership_request/models/membership_request.py
+++ b/mozaik_membership_request/models/membership_request.py
@@ -1516,6 +1516,12 @@ class MembershipRequest(models.Model):
                 mr.technical_name = res_values["technical_name"]
             if not mr.address_id:
                 mr.int_instance_ids = [(6, 0, partner.int_instance_ids.ids)]
+            if mr.address_id:
+                # Write the address on the partner, and change the instance.
+                # Only case where the instance must NOT be changed:
+                # force instance is set
+                update_instance = not bool(mr.force_int_instance_id)
+                mr._partner_write_address(mr.address_id, partner, update_instance)
 
             mr._validate_request_membership_with_checks(partner)
 
@@ -1527,13 +1533,6 @@ class MembershipRequest(models.Model):
                 # hence the force instance will not be modified inside
                 # _validate_request_membership, we must do it explicitly
                 partner_values["force_int_instance_id"] = mr.force_int_instance_id
-
-            if mr.address_id:
-                # Write the address on the partner, and change the instance.
-                # Only case where the instance must NOT be changed:
-                # force instance is set
-                update_instance = not bool(mr.force_int_instance_id)
-                mr._partner_write_address(mr.address_id, partner, update_instance)
 
             # create new involvements
             self._validate_request_involvement(mr, partner)

--- a/mozaik_membership_request/tests/test_membership_request.py
+++ b/mozaik_membership_request/tests/test_membership_request.py
@@ -727,12 +727,12 @@ class TestMembership(TransactionCase):
 
     def test_modify_partial_address(self):
         """
-        1. A member has a partial address (no street).
+        1. A member has a partial address in Liège (no street).
         We make and validate a membership request with another partial address, but from
-        another city (with another instance).
+        another city (with another instance): Namur.
         City and instance must NOT change.
 
-        2. Same test but the address on the MR is complete.
+        2. Same test but the address (in Namur) on the MR is complete.
         City and instance MUST change.
         """
         country_be = self.env.ref("base.be")
@@ -819,6 +819,7 @@ class TestMembership(TransactionCase):
                 "number": "12",
             }
         )
+        m2.onchange_city_id()
         m2.validate_request()
         self.assertEqual(harry.address_address_id.city_id, city_namur)
         self.assertEqual(harry.address_address_id.street, "Rue du Puits 12")


### PR DESCRIPTION
 This is needed for mozaik_membership_last_changes_report, otherwise
    all logged changes about an instance change are logged on the new membership line