### PR TITLE
[IMP] Membership line update buttons: dynamic domains

### DIFF
--- a/mozaik_account/views/res_partner.xml
+++ b/mozaik_account/views/res_partner.xml
@@ -28,26 +28,17 @@
                 <field name="paid" />
             </xpath>
 
-            <xpath
-                expr="//button[@name='%(mozaik_membership.update_membership_product_action)d']"
-                position="attributes"
-            >
-                <attribute
-                    name="attrs"
-                    translation="off"
-                >{'invisible': ['|', '|', ('active', '=', False), ('state_code', 'not in', ['member', 'member_candidate', 'former_member_committee', 'member_committee']), '&amp;', ('paid', '=', True), ('price', '!=', 0.0)]}</attribute>
-            </xpath>
-
              <xpath
                 expr="//button[@name='%(mozaik_membership.update_membership_product_action)d']"
                 position="after"
             >
+                    <field name="can_update_price_paid" invisible="1" />
                  <button
                     name="%(update_membership_price_paid_action)d"
                     string="Update price paid"
                     type="action"
                     groups="mozaik_account.group_can_update_price_paid"
-                    attrs="{'invisible': ['|', ('active', '=', False), ('state_code', 'not in', ['member', 'member_candidate', 'former_member_committee', 'member_committee'])]}"
+                    attrs="{'invisible': [('can_update_price_paid', '=', False)]}"
                 />
              </xpath>
 

--- a/mozaik_membership/views/res_partner.xml
+++ b/mozaik_membership/views/res_partner.xml
@@ -189,12 +189,13 @@
                             <field name="date_to" />
                             <field name="active" invisible="1" />
                             <field name="state_code" invisible="1" />
+                            <field name="can_update_product" invisible="1" />
                             <button
                                 name="%(update_membership_product_action)d"
                                 string="Update product/price"
                                 type="action"
                                 groups="mozaik_membership.res_groups_membership_manager"
-                                attrs="{'invisible': ['|', ('active', '=', False), ('state_code', 'not in', ['member', 'member_candidate', 'former_member_committee', 'member_committee'])]}"
+                                attrs="{'invisible': [('can_update_product', '=', False)]}"
                             />
                         </tree>
                     </field>

--- a/mozaik_membership/wizards/add_membership.py
+++ b/mozaik_membership/wizards/add_membership.py
@@ -53,6 +53,26 @@ class AddMembership(models.TransientModel):
         readonly=True,
     )
 
+    can_display_product_price = fields.Boolean(
+        compute="_compute_can_display_product_price"
+    )
+
+    @api.model
+    def _get_states_can_display_product_price(self):
+        """
+        Return the list of states for which the price and product
+        can be set on the membership line.
+        This corresponds to states for which the product/price can be updated
+        via the button on the membership line, once created.
+        """
+        return self.env["membership.line"]._get_states_can_update_product()
+
+    @api.depends("state_code")
+    def _compute_can_display_product_price(self):
+        allowed_states = self._get_states_can_display_product_price()
+        for wiz in self:
+            wiz.can_display_product_price = self.state_code in allowed_states
+
     @api.model
     def _get_state_domain(self):
         """

--- a/mozaik_membership/wizards/add_membership.xml
+++ b/mozaik_membership/wizards/add_membership.xml
@@ -23,17 +23,15 @@
                         <field name="state_id" widget="selection" />
                         <field name="date_from" />
                     </group>
-                    <group>
+                    <field name="can_display_product_price" invisible="1" />
+                    <group
+                        attrs="{'invisible': [('can_display_product_price', '=', False)]}"
+                    >
                         <field
                             name="product_id"
                             options="{'no_create_edit': True, 'no_create': True}"
-                            attrs="{'invisible': [('state_code', 'not in', ['member', 'member_candidate', 'former_member_committee', 'member_committee'])]}"
                         />
-                        <field
-                            name="price"
-                            attrs="{'invisible': [('state_code', 'not in', ['member', 'member_candidate', 'former_member_committee', 'member_committee'])]}"
-                        />
-                        <field name="state_code" invisible="1" />
+                        <field name="price" />
                     </group>
                 </group>
                 <footer>


### PR DESCRIPTION
For 'Update product/price' and 'Update price paid' buttons (in the tree view of membership lines, on the res partner form view), the domain was set in view, in invisible attrs.
But this domain was overwritten and needed to be overwritten once more for some parties.
We extract the computation of the visible/invisible attr in new boolean computed fields

refs #68938