### PR TITLE
[IMP] Clean incomplete demo data

### DIFF
--- a/mozaik_interest_group/tests/test_partner_involvement.py
+++ b/mozaik_interest_group/tests/test_partner_involvement.py
@@ -7,7 +7,7 @@ from odoo.tests.common import SavepointCase
 class TestPartnerInvolvement(SavepointCase):
     def setUp(self):
         super().setUp()
-        self.paul = self.browse_ref("mozaik_involvement.res_partner_bocuse")
+        self.paul = self.env["res.partner"].create({"name": "Paul Bocuse"})
         self.ig = self.env["interest.group"].create({"name": "Youths"})
         self.ic = self.env["partner.involvement.category"].create(
             {

--- a/mozaik_involvement/__manifest__.py
+++ b/mozaik_involvement/__manifest__.py
@@ -28,7 +28,6 @@
     ],
     "demo": [
         "demo/partner_involvement_category.xml",
-        "demo/res_partner.xml",
     ],
     "installable": True,
 }

--- a/mozaik_involvement/demo/res_partner.xml
+++ b/mozaik_involvement/demo/res_partner.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<!-- Copyright 2018 ACSONE SA/NV
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
-<odoo>
-    <record model="res.partner" id="res_partner_bocuse">
-        <field name="name">Bocuse Paul</field>
-    </record>
-</odoo>

--- a/mozaik_involvement/tests/test_partner_involvement.py
+++ b/mozaik_involvement/tests/test_partner_involvement.py
@@ -14,7 +14,7 @@ from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT, mute_logger
 class TestPartnerInvolvement(SavepointCase):
     def setUp(self):
         super().setUp()
-        self.paul = self.browse_ref("mozaik_involvement.res_partner_bocuse")
+        self.paul = self.env["res.partner"].create({"name": "Paul Bocuse"})
         self.ic_1 = self.browse_ref(
             "mozaik_involvement.partner_involvement_category_demo_1"
         )


### PR DESCRIPTION
Defining res.partner demo data in various addons is a bad idea as some required fields are not always set.