### PR TITLE
[DO NOT MERGE] Trying to fix pipeline slowness

### DIFF
--- a/mozaik_membership/__manifest__.py
+++ b/mozaik_membership/__manifest__.py
@@ -20,6 +20,9 @@
         "mozaik_structure",
         "mozaik_person",
         "mozaik_involvement",
+        # TODO remove
+        "pydantic",
+        "extendable",
     ],
     "data": [
         "wizards/create_user_from_partner.xml",
@@ -56,5 +59,7 @@
         "demo/res_city.xml",
     ],
     "installable": True,
-    "external_dependencies": {"python": ["openupgradelib"]},
+    "external_dependencies": {
+        "python": ["openupgradelib", "pydantic<2.0.0", "extendable_pydantic==0.0.6"]
+    },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 # generated from manifests external_dependencies
+extendable_pydantic==0.0.6
 freezegun
 graphene
 openupgradelib
 phonenumbers
+pydantic<2.0.0


### PR DESCRIPTION
This PR is only a test to run GitHub pipelines:

**Problem**: jobs on PR https://github.com/mozaik-association/mozaik/pull/765 fail because he cannot succeed installing dependencies in an efficient way. Some log lines: 

```
 Downloading https://wheelhouse.odoo-community.org/oca-simple/odoo14-addon-account-reconciliation-widget/odoo14_addon_account_reconciliation_widget-14.0.2.0.4-py3-none-any.whl (160 kB)
  Downloading https://wheelhouse.odoo-community.org/oca-simple/odoo14-addon-account-reconciliation-widget/odoo14_addon_account_reconciliation_widget-14.0.2.0.3-py3-none-any.whl (160 kB)
  Downloading https://wheelhouse.odoo-community.org/oca-simple/odoo14-addon-account-reconciliation-widget/odoo14_addon_account_reconciliation_widget-14.0.2.0.2-py3-none-any.whl (155 kB)
  Downloading https://wheelhouse.odoo-community.org/oca-simple/odoo14-addon-account-reconciliation-widget/odoo14_addon_account_reconciliation_widget-14.0.2.0.1-py3-none-any.whl (155 kB)
  Downloading https://wheelhouse.odoo-community.org/oca-simple/odoo14-addon-account-reconciliation-widget/odoo14_addon_account_reconciliation_widget-14.0.2.0.0-py3-none-any.whl (152 kB)
INFO: pip is looking at multiple versions of odoo14-addon-account-reconciliation-widget to determine which version is compatible with other requirements. This could take a while.
  Downloading https://wheelhouse.odoo-community.org/oca-simple/odoo14-addon-account-reconciliation-widget/odoo14_addon_account_reconciliation_widget-14.0.1.3.2-py3-none-any.whl (152 kB)
  Downloading https://wheelhouse.odoo-community.org/oca-simple/odoo14-addon-account-reconciliation-widget/odoo14_addon_account_reconciliation_widget-14.0.1.3.1-py3-none-any.whl (152 kB)
  Downloading https://wheelhouse.odoo-community.org/oca-simple/odoo14-addon-account-reconciliation-widget/odoo14_addon_account_reconciliation_widget-14.0.1.3.0-py3-none-any.whl (151 kB)
```

Some experiments were done here:
* Adding a dummy change in Python file -> No problem with the pipeline
* Adding `babel` as a new python external dependency in a Mozaik addon -> No problem with the pipeline
* Adding `pydantic` as a new python external dependency in a Mozaik addon -> No problem with the pipeline
* Adding `extendable_pydantic` as a new python external dependency in a Mozaik addon ->  No problem with the pipeline

-> The problem does not come from the python external dependencies. Try now to add `extendable_pydantic` and `pydantic` python libraries + the needed REST Odoo addons: 
* Adding `pydantic` Odoo addons in manifest -> No problem with the pipeline
* Adding `extendable` and `pydantic` Odoo addons in manifest -> **The problem is reproduced!**

We think the problem comes from the versions of `pydantic`, `extendable` and `extendable_pydantic`. We should continue working with Pydantic v1 and be sure all related dependencies are correctly set.