### PR TITLE
[FIX] mozaik_account: partner wasn't set on aml when info from reference was found from partner model

### DIFF
--- a/mozaik_account/models/account_bank_statement_line.py
+++ b/mozaik_account/models/account_bank_statement_line.py
@@ -40,10 +40,10 @@ class AccountBankStatementLine(models.Model):
         for model in models_mode:
             domain = [
                 (models_mode.get(model, {}).get("field", "reference"), "=", reference),
-                ("active", "<=", True),
             ]
             obj = (
                 self.env[model]
+                .with_context(active_test=False)
                 .search(domain)
                 .mapped(models_mode.get(model, {}).get("map"))
             )

--- a/mozaik_account/models/account_move_line.py
+++ b/mozaik_account/models/account_move_line.py
@@ -15,7 +15,7 @@ class AccountMoveLine(models.Model):
                 mode, partner = self.env[
                     "account.bank.statement.line"
                 ]._get_info_from_reference(vals.get("name", False))
-                if mode == "membership" and partner:
+                if mode in ["partner", "membership"] and partner:
                     vals["partner_id"] = partner.id
         return super().create(vals_list)
 


### PR DESCRIPTION
From what I understand: 2 years ago @RobinetDenisAcsone added this commit: https://github.com/mozaik-association/mozaik/commit/074d83487f9f341dcb72f12e25896b4a3cafe112

Inside this commit a new field `stored_reference` is added, hence the method `_get_info_from_reference` on `account.bank.statement.line` (finding the partner from the structured reference) had to be adapted, to include the search on this new field `stored_reference`.

But at bank statement lines reconciliation, the creation of the `account.move.line` sets the partner on it ONLY if the reference info came from a membership line, not if it came from the partner.
https://github.com/mozaik-association/mozaik/blob/fc2279d51d1dc9b64d9a16f501598bd72a73ad3f/mozaik_account/models/account_move_line.py#L18

I'm not sure of what it was done like that, but I think it was omitted.

refs #73832