### PR TITLE
[FIX] mozaik_mandate: 'all details' action with wrong active_id

### DIFF
--- a/mozaik_mandate/models/res_partner.py
+++ b/mozaik_mandate/models/res_partner.py
@@ -110,3 +110,24 @@ class ResPartner(models.Model):
             "view_mode": "form",
             "target": "new",
         }
+
+    def all_mandates_action(self):
+        self.ensure_one()
+        context = {
+            "search_default_partner_id": self.id,
+            "default_partner_id": self.id,
+            "search_default_all": True,
+        }
+        names = {
+            "sta.mandate": _("State Mandates"),
+            "int.mandate": _("Internal Mandates"),
+            "ext.mandate": _("External Mandates"),
+        }
+        mandate_model = self.env.context.get("mandate_model")
+        return {
+            "type": "ir.actions.act_window",
+            "name": names[mandate_model],
+            "res_model": mandate_model,
+            "context": context,
+            "view_mode": "tree,form",
+        }

--- a/mozaik_mandate/views/res_partner.xml
+++ b/mozaik_mandate/views/res_partner.xml
@@ -63,12 +63,10 @@
                     <button
                         class="oe_right"
                         string="All Details"
-                        name="%(sta_mandate_action)d"
-                        type="action"
+                        name="all_mandates_action"
+                        type="object"
                         attrs="{'invisible': [('id','=',False)]}"
-                        context="{'search_default_partner_id': active_id,
-                                              'default_partner_id': active_id,
-                                              'search_default_all': True}"
+                        context="{'mandate_model': 'sta.mandate'}"
                     />
                     <div style="height:10px" />
                     <button
@@ -109,12 +107,10 @@
                     <button
                         class="oe_right"
                         string="All Details"
-                        name="%(int_mandate_action)d"
-                        type="action"
+                        name="all_mandates_action"
+                        type="object"
                         attrs="{'invisible': [('id','=',False)]}"
-                        context="{'search_default_partner_id': active_id,
-                                              'default_partner_id': active_id,
-                                              'search_default_all': True}"
+                        context="{'mandate_model': 'int.mandate'}"
                     />
                     <div style="height:10px" />
                     <button
@@ -155,12 +151,10 @@
                     <button
                         class="oe_right"
                         string="All Details"
-                        name="%(ext_mandate_action)d"
-                        type="action"
+                        name="all_mandates_action"
+                        type="object"
                         attrs="{'invisible': [('id','=',False)]}"
-                        context="{'search_default_partner_id': active_id,
-                                              'default_partner_id': active_id,
-                                              'search_default_all': True}"
+                        context="{'mandate_model': 'ext.mandate'}"
                     />
                     <div style="height:10px" />
                     <button


### PR DESCRIPTION
As for other actions, there is a mix up with the ID and the active_id when having a long ariane path.
Converting the 'action' button into an 'object' button helps preventing this

refs #76024