### PR TITLE
[ADD] mozaik_privacy_domain_mixin

### DIFF
--- a/mozaik_privacy_domain_mixin/__init__.py
+++ b/mozaik_privacy_domain_mixin/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mozaik_privacy_domain_mixin/__manifest__.py
+++ b/mozaik_privacy_domain_mixin/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Mozaik Privacy Domain Mixin",
+    "summary": """
+        Mixin to add a res.partner domain on various objects,
+        for indicating which partners are concerned by the record (use case: events for eg)""",
+    "version": "14.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "ACSONE SA/NV",
+    "website": "https://github.com/mozaik-association/mozaik",
+    "depends": [
+        "base",
+    ],
+    "data": [],
+}

--- a/mozaik_privacy_domain_mixin/models/__init__.py
+++ b/mozaik_privacy_domain_mixin/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mozaik_privacy_domain_mixin

--- a/mozaik_privacy_domain_mixin/models/mozaik_privacy_domain_mixin.py
+++ b/mozaik_privacy_domain_mixin/models/mozaik_privacy_domain_mixin.py
@@ -1,0 +1,59 @@
+# Copyright 2022 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import _, api, fields, models
+from odoo.tools.safe_eval import safe_eval
+
+DEFAULT_DOMAIN = "[]"
+
+
+class PrivacyDomainMixin(models.AbstractModel):
+    _name = "mozaik.privacy.domain.mixin"
+    _description = "Mixin adding privacy domain"
+
+    domain = fields.Text(
+        string="Target partners domain",
+        help="Add a domain on partners model to limit the access to this record.",
+        default=DEFAULT_DOMAIN,
+    )
+    domain_is_set = fields.Boolean(
+        string="Domain is set",
+        compute="_compute_domain_is_set",
+        search="_search_domain_is_set",
+    )
+
+    def _search_domain_is_set(self, operator, value):
+        """
+        Cases supported are
+        * operator in ['=', '!=']
+        * value is a boolean
+        """
+        if operator not in [
+            "=",
+            "!=",
+        ] or not isinstance(value, bool):
+            raise ValueError(_("This operator/value is not supported"))
+        if operator == "!=":
+            value = not value
+        if value:
+            return [("domain", "!=", DEFAULT_DOMAIN)]
+        return [("domain", "=", DEFAULT_DOMAIN)]
+
+    @api.depends("domain")
+    def _compute_domain_is_set(self):
+        for record in self:
+            record.domain_is_set = record.domain != DEFAULT_DOMAIN
+
+    def _filter_allowed_for_partner(self, partner_id):
+        """
+        Filter the self recordset to keep only records for which partner verifies
+        the domain
+        """
+        allowed_records = self.browse()
+        for rec in self:
+            if (
+                not rec.domain_is_set
+                or partner_id
+                in self.env["res.partner"].search(safe_eval(rec.domain)).ids
+            ):
+                allowed_records |= rec
+        return allowed_records

--- a/mozaik_privacy_domain_mixin/tests/__init__.py
+++ b/mozaik_privacy_domain_mixin/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_privacy_domain_mixin

--- a/mozaik_privacy_domain_mixin/tests/models.py
+++ b/mozaik_privacy_domain_mixin/tests/models.py
@@ -1,0 +1,11 @@
+# Copyright 2024 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import models
+
+
+class ResCountryWithPrivacyDomain(models.Model):
+    _name = "res.country"
+    _inherit = ["res.country", "mozaik.privacy.domain.mixin"]
+    _description = "Adding privacy domain on countries"

--- a/mozaik_privacy_domain_mixin/tests/test_privacy_domain_mixin.py
+++ b/mozaik_privacy_domain_mixin/tests/test_privacy_domain_mixin.py
@@ -1,0 +1,49 @@
+# Copyright 2024 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_test_helper import FakeModelLoader
+
+from odoo.tests.common import SavepointCase
+
+
+class TestPrivacyDomainMixin(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+        from .models import (  # pylint: disable=import-outside-toplevel
+            ResCountryWithPrivacyDomain,
+        )
+
+        cls.loader.update_registry((ResCountryWithPrivacyDomain,))
+
+        cls.public_country = cls.env.ref("base.be")
+        cls.private_country = cls.env.ref("base.fr")
+        cls.private_country.domain = "[('email', '!=', False)]"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        super().tearDownClass()
+
+    def test_domain_is_set(self):
+        self.assertTrue(self.private_country.domain_is_set)
+        self.assertFalse(self.public_country.domain_is_set)
+        private_countries = self.env["res.country"].search(
+            [("domain_is_set", "=", True)]
+        )
+        self.assertEqual(private_countries, self.private_country)
+
+    def test_filter_allowed_for_partner(self):
+        partner = self.env["res.partner"].create({"name": "Harry Potter"})
+        allowed_countries = (
+            self.public_country | self.private_country
+        )._filter_allowed_for_partner(partner.id)
+        self.assertEqual(allowed_countries, self.public_country)
+        partner.email = "harry.potter@hogwarts.com"
+        allowed_countries = (
+            self.public_country | self.private_country
+        )._filter_allowed_for_partner(partner.id)
+        self.assertEqual(len(allowed_countries), 2)

--- a/setup/mozaik_privacy_domain_mixin/odoo/addons/mozaik_privacy_domain_mixin
+++ b/setup/mozaik_privacy_domain_mixin/odoo/addons/mozaik_privacy_domain_mixin
@@ -1,0 +1,1 @@
+../../../../mozaik_privacy_domain_mixin

--- a/setup/mozaik_privacy_domain_mixin/setup.py
+++ b/setup/mozaik_privacy_domain_mixin/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 odoo14-addon-statechart @ git+https://GitHub.com/acsone/scobidoo@14.0#subdirectory=setup/statechart
 odoo14-addon-email-template-configurator @ git+https://github.com/mozaik-association/social.git@14.0-mig-email_template_configurator#subdirectory=setup/email_template_configurator
+odoo-test-helper
 openupgradelib


### PR DESCRIPTION
This was into a specific Cdh addon (cdh_ama_objects_domain) and the code was copied on events, petitions and survey.
* Extract it into a mixin
* Put it into Mozaik as it may serve (and it will very soon, for documents, next PR)
* `is_domain_set` is computed non stored, add a `search` method and add the `filter_allowed_for_partner` method
* Add unit tests.