### PR TITLE
[FIX] mozaik_mandate: add rec_name on mandates.

### DIFF
--- a/mozaik_mandate/models/ext_mandate.py
+++ b/mozaik_mandate/models/ext_mandate.py
@@ -9,6 +9,7 @@ class ExtMandate(models.Model):
     _description = "External Mandate"
     _inherit = ["abstract.mandate"]
     _order = "partner_id, ext_assembly_id, start_date, mandate_category_id"
+    _rec_name = "mandate_category_id"
 
     _undo_redirect_action = "mozaik_mandate.ext_mandate_action"
     _unique_id_sequence = 400000000

--- a/mozaik_mandate/models/int_mandate.py
+++ b/mozaik_mandate/models/int_mandate.py
@@ -9,6 +9,7 @@ class IntMandate(models.Model):
     _name = "int.mandate"
     _description = "Internal Mandate"
     _inherit = ["abstract.mandate"]
+    _rec_name = "mandate_category_id"
 
     _undo_redirect_action = "mozaik_mandate.int_mandate_action"
     _unique_id_sequence = 0

--- a/mozaik_mandate/models/sta_mandate.py
+++ b/mozaik_mandate/models/sta_mandate.py
@@ -14,6 +14,7 @@ class StaMandate(models.Model):
     _undo_redirect_action = "mozaik_mandate.sta_mandate_action"
     _unique_id_sequence = 200000000
     _unicity_keys = "N/A"
+    _rec_name = "mandate_category_id"
 
     mandate_category_id = fields.Many2one(domain=[("type", "=", "sta")])
     legislature_id = fields.Many2one(


### PR DESCRIPTION
Without rec_name the search on the models wasn't working properly, but wasn't intuitive for the users: when they searched all mandates having a given mandate category, the result returned part of all mandates, but without any logic and any link with the mandate category.

@qgroulard FYI