### PR TITLE
[UPD] github test workflow: use python 3.8 and last version of pip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
+          - container: ghcr.io/oca/oca-ci/py3.8-odoo14.0:latest
             makepot: "true"
             name: test with Odoo
-          - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
+          - container: ghcr.io/oca/oca-ci/py3.8-ocb14.0:latest
             name: test with OCB
     services:
       postgres:
@@ -36,6 +36,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
       - name: Install addons and dependencies
         run: oca_install_addons
       - name: Check licenses


### PR DESCRIPTION
This fixes resolver issues (python3.6 is using the old resolver)

This will help us merge the Mozaik API PR (open since 2021...) 🍾

FYI @qgroulard @sbidoul 