### PR TITLE
[FIX] mozaik_partner_global_opt_out: include opt-out for mailing lists

### DIFF
--- a/mozaik_partner_global_opt_out/wizards/mail_compose_message.py
+++ b/mozaik_partner_global_opt_out/wizards/mail_compose_message.py
@@ -28,17 +28,45 @@ class MailComposeMessage(models.TransientModel):
             res.write({"include_opt_out_contacts": True})
         return res
 
+    @api.model
+    def _is_mail_canceled_because_of_opt_out(self, mail_values, res_id):
+        """
+        Odoo can cancel a mail for a lot of reasons. One of them is
+        because the email is blacklisted.
+        When we want to include opt-out contacts, we want to uncancel
+        emails (and ONLY the ones) that were canceled because
+        of a global opt-out on the partner.
+        There are different ways of performing this check, depending
+        on the mailing model.
+        This method deals with the different ways.
+        """
+        if mail_values["model"] == "res.partner":
+            return self.env["res.partner"].browse(mail_values["res_id"]).global_opt_out
+        if mail_values["model"] == "mailing.contact":
+            # Several partners can share the same email. If one of the partners
+            # has global opt out, we consider that the email itself has the global opt-out.
+            return any(
+                self.env["res.partner"]
+                .search([("email", "=", mail_values["email_to"])])
+                .mapped("global_opt_out")
+            )
+
     def _to_cancel_opt_out(
         self, opt_out_list, mail_to, mail_values, res_id, blacklisted_emails
     ):
+        """
+        This method returns the res_id of mails we REALLY want to cancel
+        (because email is blacklisted for eg).
+        If include_opt_out_contacts is set, we want to force the sending
+        of the email, hence uncancel these emails, hence we return False.
+        """
         res = super()._to_cancel_opt_out(
             opt_out_list, mail_to, mail_values, res_id, blacklisted_emails
         )
         if (
             self.include_opt_out_contacts
             and mail_values.get("state", False) == "cancel"
-            and mail_values["model"] == "res.partner"
-            and self.env["res.partner"].browse(mail_values["res_id"]).global_opt_out
+            and self._is_mail_canceled_because_of_opt_out(mail_values, res_id)
         ):
             return False
         return res


### PR DESCRIPTION
Fix the process uncanceling emails that were canceled because of a global opt-out.
The case where the mailing model is mailing.contact wasn't covered yet.

@qgroulard Mozaik being Mozaik ...
![image](https://github.com/user-attachments/assets/cdf8198d-b488-4a0e-a5dc-414db5e964c8)
