### PR TITLE
[FIX] mass_mailing_distribution_list: replace literal_eval in _parse_mailing_domain

### DIFF
--- a/mass_mailing_distribution_list/models/mailing_mailing.py
+++ b/mass_mailing_distribution_list/models/mailing_mailing.py
@@ -88,3 +88,20 @@ class MassMailing(models.Model):
 
         mass_mailings._compute_mailing_domain()
         super()._process_mass_mailing_queue()
+
+    def _parse_mailing_domain(self):
+        """
+        Override default Odoo method to replace literal_eval by eval.
+        literal_eval raises an exception if mailing_domain is too long.
+        With distribution lists this may happen frequently as self.mailing_domain
+        contains a domain of type [('id', 'in', id_list)], where id_list can be of length
+        30.000 or more.
+        """
+        self.ensure_one()
+        try:
+            mailing_domain = eval(  # pylint: disable=eval-used, eval-referenced
+                self.mailing_domain
+            )
+        except Exception:
+            mailing_domain = [("id", "in", [])]
+        return mailing_domain


### PR DESCRIPTION
Updating Odoo sources introduces a length control on the expression that is passed into literal_eval. 
See https://github.com/odoo/odoo/blob/cc0060e889603eb2e47fa44a8a22a70d7d784185/odoo/tools/_monkeypatches.py#L45
But with distribution lists, our mailing domain can be huge.