### PR TITLE
[FIX] mozaik_document: do not access content to get its size

### DIFF
--- a/mozaik_document/models/mozaik_document.py
+++ b/mozaik_document/models/mozaik_document.py
@@ -24,13 +24,15 @@ class MozaikDocument(models.Model):
     @api.depends("content")
     def _compute_content_filesize(self):
         for doc in self:
-            if not doc.content:
-                doc.content_filesize = 0
-            attachment = self.env["ir.attachment"].search(
-                [
-                    ("res_field", "=", "content"),
-                    ("res_model", "=", "mozaik.document"),
-                    ("res_id", "=", doc.id),
-                ]
+            attachment = (
+                self.env["ir.attachment"]
+                .sudo()
+                .search(
+                    [
+                        ("res_field", "=", "content"),
+                        ("res_model", "=", "mozaik.document"),
+                        ("res_id", "=", doc.id),
+                    ]
+                )
             )
-            doc.content_filesize = attachment.file_size
+            doc.content_filesize = attachment.file_size if attachment else 0

--- a/mozaik_document/models/mozaik_document.py
+++ b/mozaik_document/models/mozaik_document.py
@@ -23,16 +23,19 @@ class MozaikDocument(models.Model):
 
     @api.depends("content")
     def _compute_content_filesize(self):
-        for doc in self:
-            attachment = (
-                self.env["ir.attachment"]
-                .sudo()
-                .search(
-                    [
-                        ("res_field", "=", "content"),
-                        ("res_model", "=", "mozaik.document"),
-                        ("res_id", "=", doc.id),
-                    ]
-                )
+        attachments = (
+            self.env["ir.attachment"]
+            .sudo()
+            .search(
+                [
+                    ("res_field", "=", "content"),
+                    ("res_model", "=", "mozaik.document"),
+                    ("res_id", "in", self.ids),
+                ]
             )
-            doc.content_filesize = attachment.file_size if attachment else 0
+        )
+        file_size_by_doc_id = {
+            attachment.res_id: attachment.file_size for attachment in attachments
+        }
+        for doc in self:
+            doc.content_filesize = file_size_by_doc_id.get(doc.id, 0)


### PR DESCRIPTION
Reading the content from disk is a costly operation, and even more so using object storage.