### PR TITLE
 [FIX] Creating an event.registration and a membership.request: don't override vals dict

### DIFF
--- a/mozaik_membership_request/models/membership_request.py
+++ b/mozaik_membership_request/models/membership_request.py
@@ -1882,6 +1882,7 @@ class MembershipRequest(models.Model):
         # Automatically correct case errors in firstname and lastname
         # Will not be corrected in write() so user can bypass
         # this modification.
+        vals = vals.copy()
         for key in ["lastname", "firstname"]:
             val = vals.get(key, False)
             if val:

--- a/mozaik_membership_request_from_registration/models/membership_request.py
+++ b/mozaik_membership_request_from_registration/models/membership_request.py
@@ -37,7 +37,7 @@ class MembershipRequest(models.Model):
         #  If 'zip' is given in vals (as coming from an event for example),
         #  add it also in zip_man
         if "zip" in vals and "zip_man" not in vals:
-            vals["zip_man"] = vals["zip"]
+            vals = dict(vals, zip_man=vals["zip"])
         if self._find_lastname(vals):
             request = self.with_context(mode="pre_process").create(vals)
             return request


### PR DESCRIPTION
    Bug: When creating an event.registration, _create_membership_request method is called,
    with the same dict vals. But this dict is modified into the mentioned method. This is a bad practise
    and may lead to errors.
    For example in case of concurrent updates because of registering multiple partners on an event
    at once, Odoo retries the requests but reuses the vals dict, which was modified.
    It lead to the following error: 'field zip_man doesnt exist on model event.registration'