### PR TITLE
[IMP] mozaik_event_membership_request_partner_identifier: compute value on existing records

### DIFF
--- a/mozaik_event_membership_request_partner_identifier/__init__.py
+++ b/mozaik_event_membership_request_partner_identifier/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import post_init_hook

--- a/mozaik_event_membership_request_partner_identifier/__manifest__.py
+++ b/mozaik_event_membership_request_partner_identifier/__manifest__.py
@@ -7,7 +7,7 @@
         Glue module between 'mozaik_event_membership_request_involvement'
         and 'mozaik_event_registration_partner_identifier'.
     """,
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV",
     "website": "https://github.com/mozaik-association/mozaik",
@@ -17,4 +17,5 @@
         "mozaik_event_registration_partner_identifier",
     ],
     "data": [],
+    "post_init_hook": "post_init_hook",
 }

--- a/mozaik_event_membership_request_partner_identifier/hooks.py
+++ b/mozaik_event_membership_request_partner_identifier/hooks.py
@@ -1,0 +1,27 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def _recompute_partner_identifier(cr):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        env["event.registration"].with_context(active_test=False).search(
+            []
+        )._compute_partner_identifier()
+
+
+def post_init_hook(cr, registry):
+    """
+    Addon mozaik_event_registration_partner_identifier defines the partner_identifier
+    field on event registrations.
+    This addon override the compute method to take care of the associated_partner_id field.
+    Hence the hook computing the value on all records must be done in this module.
+    """
+    _logger.info("Fill partner_identifier on event registrations")
+    _recompute_partner_identifier(cr)

--- a/mozaik_event_membership_request_partner_identifier/migrations/14.0.1.0.1/post-migrate.py
+++ b/mozaik_event_membership_request_partner_identifier/migrations/14.0.1.0.1/post-migrate.py
@@ -1,0 +1,15 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo.addons.mozaik_event_membership_request_partner_identifier.hooks import (
+    _recompute_partner_identifier,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Compute partner_identifier on existing event registrations")
+    _recompute_partner_identifier(cr)


### PR DESCRIPTION
Add a post-init-hook (for envs where the addon isn't installed yet, like production) and a migration script (for envs where the addon is already installed, like UAT) to compute `partner_identifier` on existing event registrations.
This hook must be done in `mozaik_event_membership_request_partner_identifier`, the glue module, to be sure the override of the compute is already known by Odoo.

refs #93721

