### PR TITLE
[FIX] mozaik_person: name_search on res.partner: allow identifiers starting with 0

### DIFF
--- a/mozaik_person/models/res_partner.py
+++ b/mozaik_person/models/res_partner.py
@@ -339,7 +339,7 @@ class ResPartner(models.Model):
                 ]
                 else "ilike"
             )
-            ident = int(name) if name.isdigit() else -1
+            ident = name if name.isdigit() else -1
             domain = [
                 "|",
                 "|",


### PR DESCRIPTION

refs #94547